### PR TITLE
Keep reconnect overlay active during packet-loss retries

### DIFF
--- a/vita/src/host.c
+++ b/vita/src/host.c
@@ -487,6 +487,8 @@ static bool video_cb(uint8_t *buf, size_t buf_size, int32_t frames_lost, bool fr
   }
   if (frames_lost > 0) {
     handle_loss_event(frames_lost, frame_recovered);
+    if (context.stream.stop_requested)
+      return false;
   }
   context.stream.is_streaming = true;
   if (context.stream.reconnect_overlay_active)


### PR DESCRIPTION
This pull request introduces a small but important change to the video callback logic to improve handling when a stream stop is requested. Now, after handling a loss event, the function will immediately return if a stop has been requested, ensuring that no further processing occurs unnecessarily.

- Stream control improvement:
  * Updated the `video_cb` function in `vita/src/host.c` to check for `stop_requested` after handling lost frames, and return early if a stop is in progress.