### PR TITLE
Add logging profiles and env-controlled build defaults

### DIFF
--- a/.env.prod
+++ b/.env.prod
@@ -1,0 +1,6 @@
+# VitaRPS5 production defaults: only crash/error logs go to disk
+VITARPS5_LOG_PROFILE=errors
+VITARPS5_LOG_ENABLED=false
+VITARPS5_FORCE_ERROR_LOGGING=true
+VITARPS5_LOG_QUEUE_DEPTH=64
+VITARPS5_LOG_PATH=ux0:data/vita-chiaki/vitarps5.log

--- a/.env.testing
+++ b/.env.testing
@@ -1,0 +1,6 @@
+# VitaRPS5 developer defaults: verbose logging + larger queue
+VITARPS5_LOG_PROFILE=verbose
+VITARPS5_LOG_ENABLED=true
+VITARPS5_FORCE_ERROR_LOGGING=true
+VITARPS5_LOG_QUEUE_DEPTH=128
+VITARPS5_LOG_PATH=ux0:data/vita-chiaki/vitarps5-testing.log

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -112,10 +112,10 @@ jobs:
           cat /tmp/full_changelog.txt >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Build VPK using Docker
+      - name: Build VPK using Docker (prod env)
         run: |
           chmod +x tools/build.sh
-          ./tools/build.sh
+          ./tools/build.sh --env prod
 
       - name: Find and rename VPK
         id: find_vpk

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ The VPK file will be created in:
 
 Runtime logs (including Chiaki transport warnings) are also written to `ux0:data/vita-chiaki/vitarps5.log` on the Vita, so you can pull that file to share debug output without capturing console text.
 
+**Environment profiles:** the build script auto-loads `.env.prod` (default) or any profile you pass via `--env`. For verbose developer builds run `./tools/build.sh --env testing`; for production-ready builds stick with `--env prod`. See `docs/ai/LOGGING.md` for the variables each profile controls.
+
 **Note:** Always use `./tools/build.sh` - never call Docker manually. The script ensures the correct environment and handles versioning automatically.
 
 ### Legacy Build System

--- a/docs/INCOMPLETE_FEATURES.md
+++ b/docs/INCOMPLETE_FEATURES.md
@@ -168,16 +168,12 @@ set(VITA_VERSION "00.06")
 ## Logging & Debugging
 
 ### 10. Configurable Log Level
-**File:** `vita/src/context.c:45`
-**Status:** Not implemented
+**File:** `vita/src/config.c:194`, `vita/src/logging.c:12`
+**Status:** ✅ Completed (Nov 2025)
 **Priority:** Low
-**Description:** Log level should be configurable from config file.
+**Description:** Logging profiles can now be set via `.env` build profiles and the `[logging]` table in `chiaki.toml`. Defaults live in `vita/src/logging.c`, and runtime parsing happens in `vita/src/config.c`.
 
-```c
-// TODO: Load log level from config
-```
-
-**Impact:** Users cannot adjust logging verbosity.
+**Impact:** Developers and testers can toggle verbose/crash-only logging without editing code.
 
 ---
 

--- a/docs/ai/LOGGING.md
+++ b/docs/ai/LOGGING.md
@@ -1,0 +1,60 @@
+# VitaRPS5 Logging Guide
+
+This document covers the new logging pipeline introduced for VitaRPS5. It explains build-time profiles, runtime configuration, and how to collect logs without destabilizing the PS Vita.
+
+## Goals
+- Toggle verbose logging on/off without patching code.
+- Guarantee that crashes and `LOGE` events still hit disk, even when developers disable regular logs.
+- Capture Chiaki warnings/errors from parallel threads without stalling them.
+
+## Build-Time Profiles (`.env`)
+Use `.env` files in the repo root to seed compile-time defaults. The build script autoloads `.env.prod` (minimal logging) unless another profile is picked:
+
+```bash
+# Verbose build for developer testing
+./tools/build.sh --env testing
+
+# Force a specific file
+./tools/build.sh --env-file /path/to/custom.env
+```
+
+Supported keys inside `.env.*`:
+
+| Variable | Purpose | Example |
+|----------|---------|---------|
+| `VITARPS5_LOG_PROFILE` | Default Chiaki mask (`off`, `errors`, `standard`, `verbose`) | `VITARPS5_LOG_PROFILE=verbose` |
+| `VITARPS5_LOG_ENABLED` | Whether non-error lines go to disk by default (`true`/`false`) | `VITARPS5_LOG_ENABLED=false` |
+| `VITARPS5_FORCE_ERROR_LOGGING` | Keep `CHIAKI_LOG_ERROR`/`LOGE` on disk even if logging is off | `true` |
+| `VITARPS5_LOG_QUEUE_DEPTH` | Worker queue depth (8–256) | `128` |
+| `VITARPS5_LOG_PATH` | Default Vita log path | `ux0:data/vita-chiaki/vitarps5.log` |
+
+These values become `VITARPS5_*` compile definitions (see `tools/build.sh` and `vita/CMakeLists.txt`). The runtime defaults in `vita/src/logging.c` read them during `vita_logging_config_set_defaults()`.
+
+## Runtime Configuration (`chiaki.toml`)
+A new `[logging]` block in `ux0:data/vita-chiaki/chiaki.toml` lets testers override logging on-device without rebuilding:
+
+```toml
+[logging]
+enabled = true
+force_error_logging = true
+profile = "verbose"   # off | errors | standard | verbose
+path = "ux0:data/vita-chiaki/vitarps5.log"
+queue_depth = 128
+```
+
+Parsing logic lives in `vita/src/config.c`, and the active values are stored on `context.config.logging`. `profile` translates directly to the Chiaki mask used in `chiaki_log_init()`, so verbose builds capture Takion/hexdump information automatically.
+
+## Crash Logging Guarantee
+Even if `enabled = false`, the worker always writes `CHIAKI_LOG_ERROR` and `LOGE` messages when `force_error_logging = true`. This guarantee is enforced in `vita_log_should_write_level()` (`vita/src/logging.c`), so crash reproductions always ship with a usable `.log`.
+
+## Capturing Logs
+- Default output file: `ux0:data/vita-chiaki/vitarps5.log` (configurable via `.env` or `[logging].path`).
+- Pull the file from VitaShell (`ux0:/data/vita-chiaki/`) instead of copying console text.
+- The logging worker (`VitaLogThread`) buffers writes through a fixed queue (default 64) to avoid blocking Chiaki threads; bump `queue_depth` in verbose builds if you see drops.
+
+## Adding New Logs
+- Prefer the existing `LOGD`/`LOGE` macros (`vita/include/context.h`). They route through the shared worker and honor the active profile.
+- Only gate extremely hot loops with extra checks if needed; otherwise, rely on the logging mask/queue.
+- For Chiaki-side logs, call `chiaki_log_*()` with an appropriate level and let the profile filter the callback.
+
+When making architectural changes, update this document and cite the relevant sources (e.g., `vita/src/logging.c` or `tools/build.sh`) so reviewers can trace the behavior quickly.

--- a/vita/CMakeLists.txt
+++ b/vita/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(${VITA_APP_NAME}.elf
     src/video.c
     src/audio.c
     src/message_log.c
+    src/logging.c
 
     third_party/tomlc99/toml.c
     third_party/h264-bitstream/h264_nal.c
@@ -28,6 +29,21 @@ add_executable(${VITA_APP_NAME}.elf
 target_compile_definitions(${VITA_APP_NAME}.elf PUBLIC
     CHIAKI_VERSION="${CHIAKI_VERSION}"
 )
+if(DEFINED VITARPS5_DEFAULT_LOG_PROFILE)
+    target_compile_definitions(${VITA_APP_NAME}.elf PUBLIC VITARPS5_DEFAULT_LOG_PROFILE=${VITARPS5_DEFAULT_LOG_PROFILE})
+endif()
+if(DEFINED VITARPS5_LOGGING_DEFAULT_ENABLED)
+    target_compile_definitions(${VITA_APP_NAME}.elf PUBLIC VITARPS5_LOGGING_DEFAULT_ENABLED=${VITARPS5_LOGGING_DEFAULT_ENABLED})
+endif()
+if(DEFINED VITARPS5_LOGGING_DEFAULT_FORCE_ERRORS)
+    target_compile_definitions(${VITA_APP_NAME}.elf PUBLIC VITARPS5_LOGGING_DEFAULT_FORCE_ERRORS=${VITARPS5_LOGGING_DEFAULT_FORCE_ERRORS})
+endif()
+if(DEFINED VITARPS5_LOGGING_DEFAULT_QUEUE_DEPTH)
+    target_compile_definitions(${VITA_APP_NAME}.elf PUBLIC VITARPS5_LOGGING_DEFAULT_QUEUE_DEPTH=${VITARPS5_LOGGING_DEFAULT_QUEUE_DEPTH})
+endif()
+if(DEFINED VITARPS5_LOGGING_DEFAULT_PATH)
+    target_compile_definitions(${VITA_APP_NAME}.elf PUBLIC VITARPS5_LOGGING_DEFAULT_PATH="${VITARPS5_LOGGING_DEFAULT_PATH}")
+endif()
 
 target_include_directories(${VITA_APP_NAME}.elf PRIVATE
     include

--- a/vita/include/config.h
+++ b/vita/include/config.h
@@ -3,6 +3,7 @@
 #include <chiaki/session.h>
 
 #include "host.h"
+#include "logging.h"
 
 #define CFG_VERSION 1
 #define CFG_FILENAME "ux0:data/vita-chiaki/chiaki.toml"
@@ -46,6 +47,7 @@ typedef struct vita_chiaki_config_t {
   bool stretch_video;
   bool force_30fps;   // Drop frames locally to hold 30 fps presentation
   VitaChiakiLatencyMode latency_mode;
+  VitaLoggingConfig logging;
 } VitaChiakiConfig;
 
 void config_parse(VitaChiakiConfig* cfg);

--- a/vita/include/context.h
+++ b/vita/include/context.h
@@ -8,20 +8,18 @@
 #include "config.h"
 #include "discovery.h"
 #include "host.h"
+#include "logging.h"
 #include "message_log.h"
 #include "controller.h"
 #include "ui.h"
 // #include "debugnet.h"
-
-void vita_log_init_file(void);
-void vita_log_append(const char *msg);
 
 #define LOGD(fmt, ...) do {\
     uint64_t timestamp = sceKernelGetProcessTimeWide(); \
     char msg[800]; \
     sceClibSnprintf(msg, sizeof(msg), "[DEBUG] %ju "fmt"\n", timestamp __VA_OPT__(,) __VA_ARGS__); \
     sceClibPrintf("%s", msg); \
-    vita_log_append(msg); \
+    vita_log_submit_line(CHIAKI_LOG_DEBUG, msg); \
     if (!context.stream.is_streaming) { \
         if (context.mlog) { \
           write_message_log(context.mlog, msg); \
@@ -34,7 +32,7 @@ void vita_log_append(const char *msg);
     char msg[800]; \
     sceClibSnprintf(msg, sizeof(msg), "[ERROR] %ju "fmt"\n", timestamp __VA_OPT__(,) __VA_ARGS__); \
     sceClibPrintf("%s", msg); \
-    vita_log_append(msg); \
+    vita_log_submit_line(CHIAKI_LOG_ERROR, msg); \
     if (!context.stream.is_streaming) { \
         if (context.mlog) { \
           write_message_log(context.mlog, msg); \

--- a/vita/include/logging.h
+++ b/vita/include/logging.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <chiaki/log.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define VITA_LOG_DEFAULT_PATH "ux0:data/vita-chiaki/vitarps5.log"
+#define VITA_LOG_DEFAULT_QUEUE_DEPTH 64
+#define VITA_LOG_MAX_PATH 160
+
+typedef enum {
+  VITA_LOG_PROFILE_OFF = 0,
+  VITA_LOG_PROFILE_ERRORS,
+  VITA_LOG_PROFILE_STANDARD,
+  VITA_LOG_PROFILE_VERBOSE
+} VitaLogProfile;
+
+typedef struct vita_logging_config_t {
+  bool enabled;
+  bool force_error_logging;
+  VitaLogProfile profile;
+  char path[VITA_LOG_MAX_PATH];
+  size_t queue_depth;
+} VitaLoggingConfig;
+
+void vita_logging_config_set_defaults(VitaLoggingConfig *cfg);
+VitaLogProfile vita_logging_profile_from_string(const char *value);
+const char *vita_logging_profile_to_string(VitaLogProfile profile);
+uint32_t vita_logging_profile_mask(VitaLogProfile profile);
+
+void vita_log_module_init(const VitaLoggingConfig *cfg);
+void vita_log_module_shutdown(void);
+void vita_log_submit_line(ChiakiLogLevel level, const char *line);
+bool vita_log_should_write_level(ChiakiLogLevel level);
+const VitaLoggingConfig *vita_log_get_active_config(void);

--- a/vita/src/context.c
+++ b/vita/src/context.c
@@ -1,210 +1,20 @@
 #include <psp2/kernel/clib.h>
 #include <psp2/kernel/processmgr.h>
-#include <psp2/io/fcntl.h>
-#include <psp2/io/stat.h>
-#include <psp2/kernel/threadmgr.h>
-// #include <debugnet.h>
-
-#include "stdlib.h"
-#include <string.h>
 
 #include "message_log.h"
 #include "context.h"
 #include "config.h"
+#include "logging.h"
 #include "ui.h"
-
-#ifndef VITAKI_DISABLE_FILE_LOGGING
-#define VITAKI_DISABLE_FILE_LOGGING 1
-#endif
 
 VitaChiakiContext context;
 
-#if !VITAKI_DISABLE_FILE_LOGGING
-
-#define VITARPS5_LOG_PATH "ux0:data/vita-chiaki/vitarps5.log"
-#define VITA_LOG_QUEUE_CAP 64
-
-typedef struct {
-  char *data;
-  size_t len;
-} VitaLogMessage;
-
-static SceUID log_file_fd = -1;
-static bool log_file_failed = false;
-static SceUID log_thread_id = -1;
-static SceKernelLwMutexWork log_mutex;
-static SceKernelLwCondWork log_cond;
-static bool log_worker_initialized = false;
-static bool log_thread_should_exit = false;
-static VitaLogMessage log_queue[VITA_LOG_QUEUE_CAP];
-static size_t log_queue_head = 0;
-static size_t log_queue_tail = 0;
-
-static void vita_log_try_open(void) {
-  if (log_file_fd >= 0 || log_file_failed)
-    return;
-
-  sceIoMkdir("ux0:data", 0777);
-  sceIoMkdir("ux0:data/vita-chiaki", 0777);
-  log_file_fd = sceIoOpen(VITARPS5_LOG_PATH,
-                          SCE_O_WRONLY | SCE_O_CREAT | SCE_O_APPEND,
-                          0666);
-  if (log_file_fd >= 0) {
-    char header[96];
-    uint64_t timestamp = sceKernelGetProcessTimeWide();
-    int len = sceClibSnprintf(header, sizeof(header),
-                              "\n----- VitaRPS5 log start %ju -----\n",
-                              timestamp);
-    if (len > 0)
-      sceIoWrite(log_file_fd, header, len);
-  } else {
-    log_file_failed = true;
-    sceClibPrintf("[LOG] Failed to open %s (0x%x)\n",
-                  VITARPS5_LOG_PATH, log_file_fd);
-  }
-}
-
-static bool vita_log_queue_is_empty(void) {
-  return log_queue_head == log_queue_tail;
-}
-
-static void vita_log_queue_push_locked(char *data, size_t len) {
-  size_t next_tail = (log_queue_tail + 1) % VITA_LOG_QUEUE_CAP;
-  if (next_tail == log_queue_head) {
-    VitaLogMessage drop = log_queue[log_queue_head];
-    if (drop.data)
-      free(drop.data);
-    log_queue_head = (log_queue_head + 1) % VITA_LOG_QUEUE_CAP;
-  }
-  log_queue[log_queue_tail].data = data;
-  log_queue[log_queue_tail].len = len;
-  log_queue_tail = next_tail;
-}
-
-static bool vita_log_queue_pop_locked(VitaLogMessage *out_msg) {
-  if (vita_log_queue_is_empty())
-    return false;
-  *out_msg = log_queue[log_queue_head];
-  log_queue_head = (log_queue_head + 1) % VITA_LOG_QUEUE_CAP;
-  return true;
-}
-
-static int vita_log_thread_func(SceSize args, void *argp) {
-  (void)args;
-  (void)argp;
-
-  while (true) {
-    sceKernelLockLwMutex(&log_mutex, 1, NULL);
-    while (!log_thread_should_exit && vita_log_queue_is_empty())
-      sceKernelWaitLwCond(&log_cond, NULL);
-
-    bool should_exit = log_thread_should_exit && vita_log_queue_is_empty();
-    VitaLogMessage msg = {};
-    if (!should_exit)
-      vita_log_queue_pop_locked(&msg);
-    sceKernelUnlockLwMutex(&log_mutex, 1);
-
-    if (should_exit)
-      break;
-
-    if (msg.data && msg.len > 0) {
-      vita_log_try_open();
-      if (log_file_fd >= 0)
-        sceIoWrite(log_file_fd, msg.data, msg.len);
-      free(msg.data);
-    }
-  }
-
-  return 0;
-}
-
-static void vita_log_worker_init(void) {
-  if (log_worker_initialized)
-    return;
-
-  int res = sceKernelCreateLwMutex(&log_mutex, "VitaLogMutex", 0, 0, NULL);
-  if (res < 0) {
-    sceClibPrintf("[LOG] Failed to create log mutex (0x%x)\n", res);
-    return;
-  }
-
-  res = sceKernelCreateLwCond(&log_cond, "VitaLogCond", 0, &log_mutex, NULL);
-  if (res < 0) {
-    sceClibPrintf("[LOG] Failed to create log cond (0x%x)\n", res);
-    return;
-  }
-
-  log_thread_should_exit = false;
-  log_thread_id = sceKernelCreateThread("VitaLogThread", vita_log_thread_func,
-                                        0x40, 0x1000, 0, 0, NULL);
-  if (log_thread_id < 0) {
-    sceClibPrintf("[LOG] Failed to create log thread (0x%x)\n", log_thread_id);
-    return;
-  }
-  sceKernelStartThread(log_thread_id, 0, NULL);
-  log_worker_initialized = true;
-}
-
-void vita_log_init_file(void) {
-  vita_log_worker_init();
-  vita_log_try_open();
-}
-
-void vita_log_append(const char *msg) {
-  if (!msg || !msg[0])
-    return;
-
-  size_t len = strlen(msg);
-  if (len == 0)
-    return;
-  vita_log_worker_init();
-  if (!log_worker_initialized)
-    return;
-
-  char *copy = malloc(len);
-  if (!copy)
-    return;
-  sceClibMemcpy(copy, msg, len);
-
-  sceKernelLockLwMutex(&log_mutex, 1, NULL);
-  vita_log_queue_push_locked(copy, len);
-  sceKernelSignalLwCond(&log_cond);
-  sceKernelUnlockLwMutex(&log_mutex, 1);
-}
-
-#else
-
-void vita_log_init_file(void) {}
-void vita_log_append(const char *msg) { (void)msg; }
-
-#endif
-
 void log_cb_debugnet(ChiakiLogLevel lvl, const char *msg, void *user) {
-  // int debugnet_lvl;
-  // switch (lvl) {
-  //   case CHIAKI_LOG_ERROR:
-  //   case CHIAKI_LOG_WARNING:
-  //     debugnet_lvl = ERROR;
-  //     break;
-  //   case CHIAKI_LOG_INFO:
-  //     debugnet_lvl = INFO;
-  //     break;
-  //   // case CHIAKI_LOG_VERBOSE:
-  //   case CHIAKI_LOG_DEBUG:
-  //   // case CHIAKI_LOG_ALL:
-  //     debugnet_lvl = DEBUG;
-  //     break;
-  //   default:
-  //     return;
-  // }
-  if (lvl == CHIAKI_LOG_ALL || lvl == CHIAKI_LOG_VERBOSE) return;
-  // uint64_t timestamp = sceKernelGetProcessTimeWide();
+  (void)user;
   char line[800];
   sceClibSnprintf(line, sizeof(line), "[CHIAKI] %s\n", msg);
   sceClibPrintf("%s", line);
-  #if !VITAKI_DISABLE_FILE_LOGGING
-  vita_log_append(line);
-  #endif
+  vita_log_submit_line(lvl, line);
   if (!context.stream.is_streaming) {
       if (context.mlog) {
         write_message_log(context.mlog, line);
@@ -215,11 +25,12 @@ void log_cb_debugnet(ChiakiLogLevel lvl, const char *msg, void *user) {
 bool vita_chiaki_init_context() {
   config_parse(&context.config);
 
-  // TODO: Load log level from config
-  // TODO: Custom logging callback that logs to a file
-  chiaki_log_init(&(context.log), CHIAKI_LOG_ALL & ~(CHIAKI_LOG_VERBOSE | CHIAKI_LOG_DEBUG), &log_cb_debugnet, NULL);
+  vita_log_module_init(&context.config.logging);
+  uint32_t log_mask = vita_logging_profile_mask(context.config.logging.profile);
+  if (!log_mask)
+    log_mask = CHIAKI_LOG_ERROR | CHIAKI_LOG_WARNING;
+  chiaki_log_init(&(context.log), log_mask, &log_cb_debugnet, NULL);
   context.mlog = message_log_create();
-  vita_log_init_file();
 
   write_message_log(context.mlog, "----- Debug log start -----"); // debug
 

--- a/vita/src/logging.c
+++ b/vita/src/logging.c
@@ -1,0 +1,294 @@
+#include "logging.h"
+
+#include <psp2/io/fcntl.h>
+#include <psp2/io/stat.h>
+#include <psp2/kernel/clib.h>
+#include <psp2/kernel/processmgr.h>
+#include <psp2/kernel/threadmgr.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef VITARPS5_LOGGING_DEFAULT_ENABLED
+#define VITARPS5_LOGGING_DEFAULT_ENABLED 1
+#endif
+
+#ifndef VITARPS5_LOGGING_DEFAULT_FORCE_ERRORS
+#define VITARPS5_LOGGING_DEFAULT_FORCE_ERRORS 1
+#endif
+
+#ifndef VITARPS5_DEFAULT_LOG_PROFILE
+#define VITARPS5_DEFAULT_LOG_PROFILE VITA_LOG_PROFILE_STANDARD
+#endif
+
+#ifndef VITARPS5_LOGGING_DEFAULT_QUEUE_DEPTH
+#define VITARPS5_LOGGING_DEFAULT_QUEUE_DEPTH VITA_LOG_DEFAULT_QUEUE_DEPTH
+#endif
+
+#ifndef VITARPS5_LOGGING_DEFAULT_PATH
+#define VITARPS5_LOGGING_DEFAULT_PATH VITA_LOG_DEFAULT_PATH
+#endif
+
+typedef struct {
+  char *data;
+  size_t len;
+} VitaLogMessage;
+
+static VitaLoggingConfig active_cfg;
+static bool cfg_initialized = false;
+
+static SceUID log_file_fd = -1;
+static bool log_file_failed = false;
+static SceUID log_thread_id = -1;
+static SceKernelLwMutexWork log_mutex;
+static SceKernelLwCondWork log_cond;
+static bool log_worker_initialized = false;
+static bool log_thread_should_exit = false;
+static VitaLogMessage *log_queue = NULL;
+static size_t log_queue_head = 0;
+static size_t log_queue_tail = 0;
+static size_t log_queue_cap = 0;
+
+static bool vita_log_queue_is_empty(void) {
+  return log_queue_head == log_queue_tail;
+}
+
+static void vita_log_queue_push_locked(char *data, size_t len) {
+  size_t next_tail = (log_queue_tail + 1) % log_queue_cap;
+  if (next_tail == log_queue_head) {
+    VitaLogMessage drop = log_queue[log_queue_head];
+    if (drop.data)
+      free(drop.data);
+    log_queue_head = (log_queue_head + 1) % log_queue_cap;
+  }
+  log_queue[log_queue_tail].data = data;
+  log_queue[log_queue_tail].len = len;
+  log_queue_tail = next_tail;
+}
+
+static bool vita_log_queue_pop_locked(VitaLogMessage *out_msg) {
+  if (vita_log_queue_is_empty())
+    return false;
+  *out_msg = log_queue[log_queue_head];
+  log_queue_head = (log_queue_head + 1) % log_queue_cap;
+  return true;
+}
+
+static void vita_log_try_open(void) {
+  if (log_file_fd >= 0 || log_file_failed || !cfg_initialized)
+    return;
+
+  sceIoMkdir("ux0:data", 0777);
+  sceIoMkdir("ux0:data/vita-chiaki", 0777);
+  log_file_fd = sceIoOpen(active_cfg.path,
+                          SCE_O_WRONLY | SCE_O_CREAT | SCE_O_APPEND,
+                          0666);
+  if (log_file_fd >= 0) {
+    char header[96];
+    uint64_t timestamp = sceKernelGetProcessTimeWide();
+    int len = sceClibSnprintf(header, sizeof(header),
+                              "\n----- VitaRPS5 log start %ju -----\n",
+                              timestamp);
+    if (len > 0)
+      sceIoWrite(log_file_fd, header, len);
+  } else {
+    log_file_failed = true;
+  }
+}
+
+static int vita_log_thread_func(SceSize args, void *argp) {
+  (void)args;
+  (void)argp;
+
+  while (true) {
+    sceKernelLockLwMutex(&log_mutex, 1, NULL);
+    while (!log_thread_should_exit && vita_log_queue_is_empty())
+      sceKernelWaitLwCond(&log_cond, NULL);
+
+    bool should_exit = log_thread_should_exit && vita_log_queue_is_empty();
+    VitaLogMessage msg = {};
+    if (!should_exit)
+      vita_log_queue_pop_locked(&msg);
+    sceKernelUnlockLwMutex(&log_mutex, 1);
+
+    if (should_exit)
+      break;
+
+    if (msg.data && msg.len > 0) {
+      vita_log_try_open();
+      if (log_file_fd >= 0)
+        sceIoWrite(log_file_fd, msg.data, msg.len);
+      free(msg.data);
+    }
+  }
+
+  return 0;
+}
+
+static void vita_log_queue_destroy(void) {
+  if (!log_queue)
+    return;
+  for (size_t i = 0; i < log_queue_cap; ++i) {
+    if (log_queue[i].data)
+      free(log_queue[i].data);
+  }
+  free(log_queue);
+  log_queue = NULL;
+  log_queue_cap = 0;
+  log_queue_head = 0;
+  log_queue_tail = 0;
+}
+
+static void vita_log_worker_init(void) {
+  if (log_worker_initialized || !cfg_initialized)
+    return;
+
+  if (log_queue_cap == 0)
+    log_queue_cap = active_cfg.queue_depth > 0 ? active_cfg.queue_depth
+                                               : VITA_LOG_DEFAULT_QUEUE_DEPTH;
+  log_queue = calloc(log_queue_cap, sizeof(VitaLogMessage));
+  if (!log_queue) {
+    log_queue_cap = 0;
+    return;
+  }
+
+  int res = sceKernelCreateLwMutex(&log_mutex, "VitaLogMutex", 0, 0, NULL);
+  if (res < 0)
+    return;
+
+  res = sceKernelCreateLwCond(&log_cond, "VitaLogCond", 0, &log_mutex, NULL);
+  if (res < 0)
+    return;
+
+  log_thread_should_exit = false;
+  log_thread_id = sceKernelCreateThread("VitaLogThread", vita_log_thread_func,
+                                        0x40, 0x1000, 0, 0, NULL);
+  if (log_thread_id < 0)
+    return;
+  sceKernelStartThread(log_thread_id, 0, NULL);
+  log_worker_initialized = true;
+}
+
+void vita_logging_config_set_defaults(VitaLoggingConfig *cfg) {
+  if (!cfg)
+    return;
+  cfg->enabled = VITARPS5_LOGGING_DEFAULT_ENABLED != 0;
+  cfg->force_error_logging = VITARPS5_LOGGING_DEFAULT_FORCE_ERRORS != 0;
+  cfg->profile = VITARPS5_DEFAULT_LOG_PROFILE;
+  cfg->queue_depth = VITARPS5_LOGGING_DEFAULT_QUEUE_DEPTH;
+  memset(cfg->path, 0, sizeof(cfg->path));
+  strncpy(cfg->path, VITARPS5_LOGGING_DEFAULT_PATH, sizeof(cfg->path) - 1);
+}
+
+VitaLogProfile vita_logging_profile_from_string(const char *value) {
+  if (!value)
+    return VITA_LOG_PROFILE_STANDARD;
+  if (strcmp(value, "off") == 0)
+    return VITA_LOG_PROFILE_OFF;
+  if (strcmp(value, "errors") == 0)
+    return VITA_LOG_PROFILE_ERRORS;
+  if (strcmp(value, "verbose") == 0)
+    return VITA_LOG_PROFILE_VERBOSE;
+  return VITA_LOG_PROFILE_STANDARD;
+}
+
+const char *vita_logging_profile_to_string(VitaLogProfile profile) {
+  switch (profile) {
+    case VITA_LOG_PROFILE_OFF: return "off";
+    case VITA_LOG_PROFILE_ERRORS: return "errors";
+    case VITA_LOG_PROFILE_VERBOSE: return "verbose";
+    case VITA_LOG_PROFILE_STANDARD:
+    default:
+      return "standard";
+  }
+}
+
+uint32_t vita_logging_profile_mask(VitaLogProfile profile) {
+  switch (profile) {
+    case VITA_LOG_PROFILE_OFF:
+    case VITA_LOG_PROFILE_ERRORS:
+      return CHIAKI_LOG_ERROR | CHIAKI_LOG_WARNING;
+    case VITA_LOG_PROFILE_VERBOSE:
+      return CHIAKI_LOG_ALL;
+    case VITA_LOG_PROFILE_STANDARD:
+    default:
+      return CHIAKI_LOG_ALL & ~(CHIAKI_LOG_VERBOSE | CHIAKI_LOG_DEBUG);
+  }
+}
+
+void vita_log_module_init(const VitaLoggingConfig *cfg) {
+  vita_logging_config_set_defaults(&active_cfg);
+  if (cfg)
+    memcpy(&active_cfg, cfg, sizeof(VitaLoggingConfig));
+  if (active_cfg.queue_depth == 0)
+    active_cfg.queue_depth = VITA_LOG_DEFAULT_QUEUE_DEPTH;
+  if (active_cfg.queue_depth > 256)
+    active_cfg.queue_depth = 256;
+  if (!active_cfg.path[0])
+    strncpy(active_cfg.path, VITA_LOG_DEFAULT_PATH, sizeof(active_cfg.path) - 1);
+  log_queue_cap = active_cfg.queue_depth;
+  cfg_initialized = true;
+}
+
+void vita_log_module_shutdown(void) {
+  if (log_worker_initialized) {
+    sceKernelLockLwMutex(&log_mutex, 1, NULL);
+    log_thread_should_exit = true;
+    sceKernelSignalLwCond(&log_cond);
+    sceKernelUnlockLwMutex(&log_mutex, 1);
+    sceKernelWaitThreadEnd(log_thread_id, NULL, NULL);
+    log_thread_id = -1;
+    sceKernelDeleteLwCond(&log_cond);
+    sceKernelDeleteLwMutex(&log_mutex);
+    log_worker_initialized = false;
+  }
+
+  vita_log_queue_destroy();
+
+  if (log_file_fd >= 0) {
+    sceIoClose(log_file_fd);
+    log_file_fd = -1;
+  }
+  log_file_failed = false;
+}
+
+bool vita_log_should_write_level(ChiakiLogLevel level) {
+  if (!cfg_initialized)
+    return false;
+  bool is_error_or_warning = (level == CHIAKI_LOG_ERROR ||
+                              level == CHIAKI_LOG_WARNING);
+  if (!active_cfg.enabled)
+    return active_cfg.force_error_logging && is_error_or_warning;
+  return true;
+}
+
+void vita_log_submit_line(ChiakiLogLevel level, const char *line) {
+  if (!line || !line[0])
+    return;
+  if (!vita_log_should_write_level(level))
+    return;
+
+  size_t len = strlen(line);
+  if (len == 0)
+    return;
+
+  vita_log_worker_init();
+  if (!log_worker_initialized)
+    return;
+
+  char *copy = malloc(len);
+  if (!copy)
+    return;
+  memcpy(copy, line, len);
+
+  sceKernelLockLwMutex(&log_mutex, 1, NULL);
+  vita_log_queue_push_locked(copy, len);
+  sceKernelSignalLwCond(&log_cond);
+  sceKernelUnlockLwMutex(&log_mutex, 1);
+}
+
+const VitaLoggingConfig *vita_log_get_active_config(void) {
+  if (!cfg_initialized)
+    return NULL;
+  return &active_cfg;
+}


### PR DESCRIPTION
This pull request introduces a comprehensive, configurable logging pipeline for VitaRPS5, allowing developers and testers to control log verbosity and crash/error persistence via build-time profiles and runtime configuration. The build system now supports `.env` profiles for logging defaults, which are passed as compile-time flags, and a new `[logging]` block in `chiaki.toml` enables on-device overrides. Documentation and tooling have been updated to reflect these changes, and the codebase now includes a dedicated logging module for streamlined integration.

**Build System & Environment Profiles**
* Added `.env.prod` and `.env.testing` files to define logging defaults for production and developer builds, respectively. These profiles control log verbosity, error persistence, queue depth, and log file path. (`.env.prod`, `.env.testing`) [[1]](diffhunk://#diff-b26af0b14c436b4390c93b145fca85f16b5bac28359a6ecdd6e4ea0524081b33R1-R6) [[2]](diffhunk://#diff-0ce2b24417ad4fd3d196d9b3e9a715e06581ce6d53b1173f539e954af82790edR1-R6)
* Enhanced `tools/build.sh` to support `--env` and `--env-file` options, auto-load environment profiles, and propagate logging-related settings as CMake definitions for compile-time configuration. (`tools/build.sh`) [[1]](diffhunk://#diff-992789c80d1734cb0626b8b6622caffc86d62d104fbe1e36039f82e63900cb4dR37-R120) [[2]](diffhunk://#diff-992789c80d1734cb0626b8b6622caffc86d62d104fbe1e36039f82e63900cb4dR201) [[3]](diffhunk://#diff-992789c80d1734cb0626b8b6622caffc86d62d104fbe1e36039f82e63900cb4dL152-R239) [[4]](diffhunk://#diff-992789c80d1734cb0626b8b6622caffc86d62d104fbe1e36039f82e63900cb4dR333) [[5]](diffhunk://#diff-992789c80d1734cb0626b8b6622caffc86d62d104fbe1e36039f82e63900cb4dL337-R425) [[6]](diffhunk://#diff-992789c80d1734cb0626b8b6622caffc86d62d104fbe1e36039f82e63900cb4dR441-R445) [[7]](diffhunk://#diff-992789c80d1734cb0626b8b6622caffc86d62d104fbe1e36039f82e63900cb4dL364-R503) [[8]](diffhunk://#diff-992789c80d1734cb0626b8b6622caffc86d62d104fbe1e36039f82e63900cb4dL401-R534) [[9]](diffhunk://#diff-992789c80d1734cb0626b8b6622caffc86d62d104fbe1e36039f82e63900cb4dL413-R546)

**CMake & Application Integration**
* Updated `vita/CMakeLists.txt` to conditionally add logging configuration flags from environment profiles as compile-time definitions, ensuring that logging behavior matches the selected build profile. (`vita/CMakeLists.txt`)
* Integrated the new logging module into the build and application sources, including header and source file additions. (`vita/CMakeLists.txt`, `vita/include/logging.h`) [[1]](diffhunk://#diff-ad536f2c683c4c09c4603a008d3b3ca7ec630130b43d5e95a24ffa5938785bd1R20) [[2]](diffhunk://#diff-052d1be09d1114ffe9d326234d3eb1281a7ca929e2fa02ad3ee2d846dd9eec07R1-R36)

**Runtime Configuration & Logging Module**
* Extended the configuration system to support a `[logging]` section in `chiaki.toml`, allowing runtime overrides of logging settings such as verbosity, error persistence, queue depth, and log file path. (`vita/include/config.h`, `vita/src/config.c`) [[1]](diffhunk://#diff-17b7e0bd587a3cf24bab3652aa8a0c0b3ae1aba98e9b4b027d08664f9c41004bR50) [[2]](diffhunk://#diff-d6cb19c196ba98f78b8d053ae8d20d22efb38259e23c5fa8f7797b0ad62662d9R111)
* Implemented a dedicated logging module (`vita/include/logging.h`) with support for profiles, error guarantees, queueing, and integration with existing macros. [[1]](diffhunk://#diff-052d1be09d1114ffe9d326234d3eb1281a7ca929e2fa02ad3ee2d846dd9eec07R1-R36) [[2]](diffhunk://#diff-ecbe22af3ccf7f73614e65fd557896ca077c8628dbb73f17ad0d72a6005b0370R11-R22) [[3]](diffhunk://#diff-ecbe22af3ccf7f73614e65fd557896ca077c8628dbb73f17ad0d72a6005b0370L37-R35)

**Documentation Updates**
* Added `docs/ai/LOGGING.md` to explain the new logging pipeline, environment profiles, runtime overrides, and crash/error guarantees. Updated `README.md` and `docs/INCOMPLETE_FEATURES.md` to reflect the new logging features and usage instructions. (`docs/ai/LOGGING.md`, `README.md`, `docs/INCOMPLETE_FEATURES.md`) [[1]](diffhunk://#diff-f3902f3cd2661bd56ff24090de26ab61501c4c0f714ce9762a75bb59594fded2R1-R60) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R120-R121) [[3]](diffhunk://#diff-4cba6cd536eacd1becd372569ef92bbd45fcb97ce83e8c9ac33f482cd09e9c17L171-R176)

**Release Workflow**
* Modified the GitHub Actions release workflow to explicitly build production VPKs with the correct environment profile. (`.github/workflows/create_release.yml`)

These changes make logging much more flexible and robust, enabling easier debugging and crash reproduction while minimizing performance impact in production builds.