### PR TITLE
Soft restart cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Some configuration lacks a UI but can be set in the config file located at `ux0:
 - `force_30fps = false` disables the new 30 fps presentation clamp. Set to `true` (or toggle “Force 30 FPS Output” under Streaming Settings) to make the Vita drop frames locally whenever the PS5 insists on a 60 fps stream. This keeps GPU workload and perceived latency closer to native 30 fps behavior at the cost of visual smoothness.
 - `send_actual_start_bitrate = true` sends the requested bitrate (from the latency preset) in the `RP-StartBitrate` header. Flip to `false` to fall back to zeroed headers while A/B testing packet-loss behavior.
   - **PS5 Quirk:** Current PS5 firmware ignores the `RP-StartBitrate` hint and immediately forces ~1.5 Mbps streams even when lower presets or LaunchSpec values are requested. Keep this flag enabled for telemetry and future firmware checks, but expect the console to override the requested rate.
+- `clamp_soft_restart_bitrate = true` forces all Chiaki soft restarts to request ≤1.5 Mbps. Leave this enabled (or toggle “Clamp Soft Restart Bitrate” under Streaming Settings) to keep packet-loss fallbacks from spiking the Vita’s Wi-Fi when PS5 renegotiates.
 
 ## Known issues & troubleshooting
 - Latency. On remote connections (not local WLAN), it's especially bad. ([Relevant GitHub issue](https://github.com/ywnico/vitaki-fork/issues/12))

--- a/vita/include/config.h
+++ b/vita/include/config.h
@@ -47,6 +47,7 @@ typedef struct vita_chiaki_config_t {
   bool stretch_video;
   bool force_30fps;   // Drop frames locally to hold 30 fps presentation
   bool send_actual_start_bitrate; // Guard for RP-StartBitrate payload
+  bool clamp_soft_restart_bitrate; // Keep soft restart bitrate <= ~1.5 Mbps
   VitaChiakiLatencyMode latency_mode;
   VitaLoggingConfig logging;
 } VitaChiakiConfig;

--- a/vita/src/config.c
+++ b/vita/src/config.c
@@ -109,6 +109,7 @@ void config_parse(VitaChiakiConfig* cfg) {
   cfg->stretch_video = false;
   cfg->force_30fps = false;
   cfg->send_actual_start_bitrate = true;
+  cfg->clamp_soft_restart_bitrate = true;
   vita_logging_config_set_defaults(&cfg->logging);
 
   bool circle_btn_confirm_default = get_circle_btn_confirm_default();
@@ -185,6 +186,9 @@ void config_parse(VitaChiakiConfig* cfg) {
 
       datum = toml_bool_in(settings, "send_actual_start_bitrate");
       cfg->send_actual_start_bitrate = datum.ok ? datum.u.b : true;
+
+      datum = toml_bool_in(settings, "clamp_soft_restart_bitrate");
+      cfg->clamp_soft_restart_bitrate = datum.ok ? datum.u.b : true;
 
       datum = toml_string_in(settings, "latency_mode");
       if (datum.ok) {
@@ -476,6 +480,8 @@ void config_serialize(VitaChiakiConfig* cfg) {
           cfg->force_30fps ? "true" : "false");
   fprintf(fp, "send_actual_start_bitrate = %s\n",
           cfg->send_actual_start_bitrate ? "true" : "false");
+  fprintf(fp, "clamp_soft_restart_bitrate = %s\n",
+          cfg->clamp_soft_restart_bitrate ? "true" : "false");
   fprintf(fp, "latency_mode = \"%s\"\n", serialize_latency_mode(cfg->latency_mode));
   fprintf(fp, "\n[logging]\n");
   fprintf(fp, "enabled = %s\n", cfg->logging.enabled ? "true" : "false");

--- a/vita/src/host.c
+++ b/vita/src/host.c
@@ -386,7 +386,8 @@ static bool request_stream_restart(uint32_t bitrate_kbps) {
     profile.bitrate = bitrate_kbps;
   }
 
-  if (profile.bitrate > FAST_RESTART_BITRATE_CAP_KBPS) {
+  if (context.config.clamp_soft_restart_bitrate &&
+      profile.bitrate > FAST_RESTART_BITRATE_CAP_KBPS) {
     LOGD("Soft restart bitrate %u kbps exceeds cap %u kbps — clamping",
          profile.bitrate, FAST_RESTART_BITRATE_CAP_KBPS);
     profile.bitrate = FAST_RESTART_BITRATE_CAP_KBPS;

--- a/vita/src/ui.c
+++ b/vita/src/ui.c
@@ -1662,10 +1662,19 @@ static void draw_settings_streaming_tab(int content_x, int content_y, int conten
                         UI_COLOR_TEXT_PRIMARY, FONT_SIZE_BODY, "Show Latency");
   y += item_h + item_spacing;
 
+  // Clamp soft restart bitrate toggle
+  draw_toggle_switch(content_x + content_w - 70, y + (item_h - 30)/2, 60, 30,
+                     get_toggle_animation_value(7, context.config.clamp_soft_restart_bitrate),
+                     settings_state.selected_item == 6);
+  vita2d_font_draw_text(font, content_x + 15, y + item_h/2 + 6,
+                        UI_COLOR_TEXT_PRIMARY, FONT_SIZE_BODY,
+                        "Clamp Soft Restart Bitrate");
+  y += item_h + item_spacing;
+
   // Video stretch toggle
   draw_toggle_switch(content_x + content_w - 70, y + (item_h - 30)/2, 60, 30,
                      get_toggle_animation_value(6, context.config.stretch_video),
-                     settings_state.selected_item == 6);
+                     settings_state.selected_item == 7);
   vita2d_font_draw_text(font, content_x + 15, y + item_h/2 + 6,
                         UI_COLOR_TEXT_PRIMARY, FONT_SIZE_BODY, "Fill Screen");
 }
@@ -1732,7 +1741,7 @@ bool draw_settings() {
   // === INPUT HANDLING ===
 
   // No tab switching needed - only one section
-  int max_items = 7; // Resolution, Latency Mode, FPS, Force 30 FPS, Auto Discovery, Show Latency, Fill Screen
+  int max_items = 8; // Resolution, Latency Mode, FPS, Force 30 FPS, Auto Discovery, Show Latency, Clamp, Fill Screen
 
   // Up/Down: Navigate items
   if (btn_pressed(SCE_CTRL_UP)) {
@@ -1787,6 +1796,10 @@ bool draw_settings() {
       start_toggle_animation(5, context.config.show_latency);
       config_serialize(&context.config);
         } else if (settings_state.selected_item == 6) {
+          context.config.clamp_soft_restart_bitrate = !context.config.clamp_soft_restart_bitrate;
+          start_toggle_animation(7, context.config.clamp_soft_restart_bitrate);
+          config_serialize(&context.config);
+        } else if (settings_state.selected_item == 7) {
           context.config.stretch_video = !context.config.stretch_video;
           start_toggle_animation(6, context.config.stretch_video);
           config_serialize(&context.config);


### PR DESCRIPTION
- vita/src/host.c:33-44 & 374-407: soft restarts now clamp their requested bitrate only when context.config.clamp_soft_restart_bitrate is true, logging when PS5 tries to exceed the 1.5 Mbps ceiling.
- vita/include/config.h:45-52 plus vita/src/config.c:100-200 & 456-485: added clamp_soft_restart_bitrate to the persisted config with a default of true, and wired TOML parsing/serialization so the flag survives reboots.
- vita/src/ui.c:1623-1805: the Streaming Settings screen gained a “Clamp Soft Restart Bitrate” toggle (with proper navigation and animation indices) positioned between “Show Latency” and “Fill Screen”.
- README.md:200-207: documented the new config option in plain language so users know it keeps PS5 renegotiations under the Vita-safe 1.5 Mbps mark.
