### PR TITLE
Keep connection overlay active through console wake

### DIFF
--- a/vita/include/host.h
+++ b/vita/include/host.h
@@ -37,6 +37,7 @@ void host_free(VitaChiakiHost* host);
 int host_register(VitaChiakiHost* host, int pin);
 int host_wakeup(VitaChiakiHost* host);
 int host_stream(VitaChiakiHost* host);
+void host_cancel_stream_request(void);
 bool mac_addrs_match(MacAddr* a, MacAddr* b);
 void save_manual_host(VitaChiakiHost* rhost, char* new_hostname);
 void delete_manual_host(VitaChiakiHost* mhost);

--- a/vita/include/ui.h
+++ b/vita/include/ui.h
@@ -32,3 +32,17 @@ typedef enum ui_main_widget_id_t {
 
 void draw_ui();
 void ui_clear_waking_wait(void);
+
+typedef enum {
+  UI_CONNECTION_STAGE_NONE = 0,
+  UI_CONNECTION_STAGE_WAKING,
+  UI_CONNECTION_STAGE_CONNECTING,
+  UI_CONNECTION_STAGE_STARTING_STREAM,
+} UIConnectionStage;
+
+void ui_connection_begin(UIConnectionStage stage);
+void ui_connection_set_stage(UIConnectionStage stage);
+void ui_connection_complete(void);
+void ui_connection_cancel(void);
+bool ui_connection_overlay_active(void);
+UIConnectionStage ui_connection_stage(void);

--- a/vita/src/discovery.c
+++ b/vita/src/discovery.c
@@ -12,6 +12,7 @@
 #include "discovery.h"
 #include "context.h"
 #include "host.h"
+#include "ui.h"
 #include "util.h"
 
 /// Allow some grace time before removing a flapping host
@@ -218,7 +219,11 @@ static void remove_lost_discovered_hosts(void) {
       bool active_streaming = (context.active_host == h) &&
                               (context.stream.session_init ||
                                context.stream.is_streaming);
+      bool connection_overlay_guard = ui_connection_overlay_active() &&
+                                      context.active_host == h;
       if (active_streaming)
+        continue;
+      if (connection_overlay_guard)
         continue;
 
       uint64_t last_seen = h->last_discovery_seen_us;


### PR DESCRIPTION
  - vita/src/ui.c, vita/include/ui.h: introduced a persistent connection
    overlay state machine and a Vita-native worker thread so host_stream() runs
    asynchronously; overlay now transitions from “Waking console” to “Starting
    stream” without dropping back to the main UI, and cancel uses a custom-drawn
    circle icon (draw_circle_outline_simple).
  - vita/src/host.c, vita/include/host.h: exposed host_cancel_stream_request()
    for UI cancels and moved overlay-stage updates
    (UI_CONNECTION_STAGE_STARTING_STREAM, etc.) into the Chiaki event path so the
    UI reflects actual connection status.
  - vita/src/discovery.c: skips removing discovered hosts while the overlay is
    active for that host, preventing discovery flaps from canceling the loading
    screen mid-wake.
