### PR TITLE
fix(ui): Fix d-pad navigation bugs in focus manager

### DIFF
--- a/vita/include/ui/ui_internal.h
+++ b/vita/include/ui/ui_internal.h
@@ -190,7 +190,7 @@ void ui_draw_loss_indicator(void);
 #define nav_screen_for_index(i) ui_nav_screen_for_icon(i)
 #define nav_touch_hit(x, y, out) ui_nav_handle_touch(x, y, out)
 #define pill_touch_hit(x, y) ui_nav_handle_pill_touch(x, y)
-#define handle_global_nav_shortcuts(out, dpad) ui_nav_handle_shortcuts(out, dpad)
+#define handle_global_nav_shortcuts(screen, out, dpad) ui_nav_handle_shortcuts(screen, out, dpad)
 
 // Procedural icon drawing (available globally)
 #define draw_play_icon(cx, cy, sz) ui_nav_draw_play_icon(cx, cy, sz)

--- a/vita/include/ui/ui_navigation.h
+++ b/vita/include/ui/ui_navigation.h
@@ -130,6 +130,13 @@ void ui_nav_set_selected_icon(int index);
  */
 UIScreenType ui_nav_screen_for_icon(int index);
 
+/**
+ * Map screen type to corresponding icon index
+ * @param screen Screen type
+ * @return Icon index (0=Play, 1=Settings, 2=Controller, 3=Profile)
+ */
+int ui_nav_icon_for_screen(UIScreenType screen);
+
 // Legacy focus getters/setters removed in Phase 4
 // Use ui_focus_get_zone()/ui_focus_set_zone() from ui_focus.h instead
 
@@ -156,11 +163,12 @@ bool ui_nav_handle_pill_touch(float x, float y);
 
 /**
  * Handle global navigation shortcuts (Triangle button, D-pad navigation)
+ * @param current_screen Current screen type (for icon sync on expand)
  * @param out_screen Output parameter for selected screen type (can be NULL)
  * @param allow_dpad True to enable D-pad navigation handling
  * @return true if navigation action was taken (screen change)
  */
-bool ui_nav_handle_shortcuts(UIScreenType *out_screen, bool allow_dpad);
+bool ui_nav_handle_shortcuts(UIScreenType current_screen, UIScreenType *out_screen, bool allow_dpad);
 
 // ============================================================================
 // Update Functions

--- a/vita/src/ui/ui_navigation.c
+++ b/vita/src/ui/ui_navigation.c
@@ -685,6 +685,16 @@ UIScreenType ui_nav_screen_for_icon(int index) {
     }
 }
 
+int ui_nav_icon_for_screen(UIScreenType screen) {
+    switch (screen) {
+        case UI_SCREEN_TYPE_MAIN:       return 0;  // Play icon
+        case UI_SCREEN_TYPE_SETTINGS:   return 1;  // Settings icon
+        case UI_SCREEN_TYPE_CONTROLLER: return 2;  // Controller icon
+        case UI_SCREEN_TYPE_PROFILE:    return 3;  // Profile icon
+        default:                        return 0;
+    }
+}
+
 // Legacy focus getters/setters removed - use ui_focus_get_zone()/ui_focus_set_zone() directly
 
 // ============================================================================
@@ -722,9 +732,14 @@ bool ui_nav_handle_pill_touch(float touch_x, float touch_y) {
             touch_y >= y - pad && touch_y <= y + h + pad);
 }
 
-bool ui_nav_handle_shortcuts(UIScreenType *out_screen, bool allow_dpad) {
+bool ui_nav_handle_shortcuts(UIScreenType current_screen, UIScreenType *out_screen, bool allow_dpad) {
     // Triangle button toggles sidebar collapse (global, works anywhere)
     if (btn_pressed(SCE_CTRL_TRIANGLE)) {
+        // When expanding, sync icon to current screen and move focus to nav bar
+        if (nav_collapse.state == NAV_STATE_COLLAPSED) {
+            selected_nav_icon = ui_nav_icon_for_screen(current_screen);
+            ui_focus_move_to_nav_bar();
+        }
         ui_nav_toggle();
         // Don't return - let other input processing continue
     }
@@ -785,16 +800,14 @@ bool ui_nav_handle_shortcuts(UIScreenType *out_screen, bool allow_dpad) {
             selected_nav_icon = (selected_nav_icon - 1 + 4) % 4;
             if (out_screen) {
                 *out_screen = ui_nav_screen_for_icon(selected_nav_icon);
-                // Reset focus to content area for the new screen
-                ui_focus_set_zone(ui_focus_zone_for_screen(*out_screen));
+                // Page changes but focus stays on nav bar for continued D-pad navigation
             }
             return true;
         } else if (btn_pressed(SCE_CTRL_DOWN)) {
             selected_nav_icon = (selected_nav_icon + 1) % 4;
             if (out_screen) {
                 *out_screen = ui_nav_screen_for_icon(selected_nav_icon);
-                // Reset focus to content area for the new screen
-                ui_focus_set_zone(ui_focus_zone_for_screen(*out_screen));
+                // Page changes but focus stays on nav bar for continued D-pad navigation
             }
             return true;
         }

--- a/vita/src/ui/ui_screens.c
+++ b/vita/src/ui/ui_screens.c
@@ -379,7 +379,7 @@ UIScreenType draw_main_menu() {
   ui_particles_render();
 
   UIScreenType nav_screen;
-  if (handle_global_nav_shortcuts(&nav_screen, true))
+  if (handle_global_nav_shortcuts(UI_SCREEN_TYPE_MAIN, &nav_screen, true))
     return nav_screen;
 
   // Render VitaRPS5 console cards instead of host tiles
@@ -715,7 +715,7 @@ UIScreenType draw_settings() {
   ui_particles_render();
 
   UIScreenType nav_screen;
-  if (handle_global_nav_shortcuts(&nav_screen, true))
+  if (handle_global_nav_shortcuts(UI_SCREEN_TYPE_SETTINGS, &nav_screen, true))
     return nav_screen;
 
   // Main content area (nav is overlay - content centered on full screen)
@@ -1103,7 +1103,7 @@ UIScreenType draw_profile_screen() {
   ui_particles_render();
 
   UIScreenType nav_screen;
-  if (handle_global_nav_shortcuts(&nav_screen, true))
+  if (handle_global_nav_shortcuts(UI_SCREEN_TYPE_PROFILE, &nav_screen, true))
     return nav_screen;
 
   // Main content area (nav is overlay - content centered on full screen)
@@ -1428,7 +1428,7 @@ UIScreenType draw_controller_config_screen() {
   ui_particles_render();
 
   UIScreenType nav_screen;
-  if (handle_global_nav_shortcuts(&nav_screen, true))
+  if (handle_global_nav_shortcuts(UI_SCREEN_TYPE_CONTROLLER, &nav_screen, true))
     return nav_screen;
 
   // Main content area (nav is overlay - content centered on full screen)


### PR DESCRIPTION
## Summary

Complete fix for D-pad navigation bugs in the focus manager system:

- **Fix UP/DOWN focus transfer**: When pressing UP/DOWN on the nav bar, focus was incorrectly transferring to content area. Now focus stays on nav bar for continued navigation.

- **Fix RIGHT button behavior**: After pressing UP/DOWN, the RIGHT button appeared broken because focus had moved to content. Now RIGHT properly moves focus to content and collapses nav.

- **Fix Triangle menu icon selection**: When pressing Triangle to open nav menu, no icon was highlighted. Now the icon corresponding to the current screen is automatically selected and highlighted.

## Changes

| File | Changes |
|------|---------|
| `vita/src/ui/ui_navigation.c` | Added `ui_nav_icon_for_screen()`, updated signature, modified Triangle handler, removed UP/DOWN focus transfer |
| `vita/include/ui/ui_navigation.h` | Added function declarations, updated signature |
| `vita/include/ui/ui_internal.h` | Updated macro signature |
| `vita/src/ui/ui_screens.c` | Updated 4 callers to pass current screen |

## Test plan

- [ ] Press LEFT to expand nav bar, then UP/DOWN - icons should cycle, pages change, nav stays focused
- [ ] Press RIGHT on nav bar - focus moves to content, nav collapses
- [ ] Press Triangle on Main screen - Play icon should be highlighted
- [ ] Press Triangle on Settings screen - Settings icon should be highlighted
- [ ] Press Triangle on Controller screen - Controller icon should be highlighted
- [ ] Press Triangle on Profile screen - Profile icon should be highlighted

🤖 Generated with [Claude Code](https://claude.com/claude-code)