### PR TITLE
fix(ui): Remove LEFT D-pad menu opening behavior

### DIFF
--- a/vita/include/ui/ui_focus.h
+++ b/vita/include/ui/ui_focus.h
@@ -68,7 +68,9 @@ int ui_focus_get_stack_depth(void);
 // ============================================================================
 
 /**
- * Handle zone-crossing input (LEFT/RIGHT between nav bar and content)
+ * Handle zone-crossing input (RIGHT to exit nav bar to content).
+ * Note: LEFT navigation to open nav bar has been removed to avoid interfering
+ * with content-specific navigation. Nav bar is now accessible only via touch.
  * Call this FIRST in each frame, before screen-specific handling.
  *
  * @param current_screen The currently displayed screen type

--- a/vita/src/ui/ui_focus.c
+++ b/vita/src/ui/ui_focus.c
@@ -121,12 +121,9 @@ bool ui_focus_handle_zone_crossing(UIScreenType current_screen) {
         return false;
     }
 
-    // LEFT: Move to nav bar (from any content zone)
-    if (ui_input_btn_pressed(SCE_CTRL_LEFT) && ui_focus_is_content()) {
-        ui_focus_move_to_nav_bar();
-        ui_nav_request_expand();
-        return true;  // Input consumed
-    }
+    // Note: LEFT navigation (content -> nav bar) was removed to avoid
+    // interfering with content-specific LEFT/RIGHT navigation.
+    // Nav bar is now accessible only via touch on the pill.
 
     // RIGHT: Move to content (from nav bar)
     if (ui_input_btn_pressed(SCE_CTRL_RIGHT) && ui_focus_is_nav_bar()) {


### PR DESCRIPTION
## Summary
- Removed LEFT D-pad zone crossing behavior that was opening the nav bar menu when pressing LEFT in content pages
- This was interfering with content-specific navigation (e.g., selecting items, moving cursor left)
- Nav bar is now accessible only via touch on the navigation pill

## Changes
- `vita/src/ui/ui_focus.c`: Removed LEFT D-pad handling block from `ui_focus_handle_zone_crossing()`
- `vita/include/ui/ui_focus.h`: Updated documentation to reflect the change

## Behavior After Fix
| Input | Before | After |
|-------|--------|-------|
| LEFT D-pad in content | Opens nav bar | Handled by content screen |
| RIGHT D-pad in nav bar | Returns to content | Returns to content (unchanged) |
| Touch on pill | Opens nav bar | Opens nav bar (unchanged) |

## Test plan
- [ ] Verify LEFT D-pad no longer opens menu from Main screen
- [ ] Verify LEFT D-pad no longer opens menu from Settings screen
- [ ] Verify LEFT D-pad no longer opens menu from Profile screen
- [ ] Verify RIGHT D-pad still exits nav bar to content
- [ ] Verify touch on nav pill still opens nav bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)