### PR TITLE
Refactor UI modal ownership and remove scattered modal guards

### DIFF
--- a/vita/include/ui.h
+++ b/vita/include/ui.h
@@ -17,8 +17,11 @@ typedef struct vita_chiaki_ui_state_t {
   int mlog_line_offset;
   uint64_t mlog_last_update;
   bool error_popup_active;
+  bool error_popup_modal_pushed;
   char error_popup_text[128];
   bool debug_menu_active;
+  bool debug_menu_modal_pushed;
+  bool register_host_modal_pushed;
   int debug_menu_selection;
 } VitaChiakiUIState;
 

--- a/vita/src/ui.c
+++ b/vita/src/ui.c
@@ -449,7 +449,10 @@ void draw_ui() {
 
   UIScreenType screen = UI_SCREEN_TYPE_MAIN;
   context.ui_state.debug_menu_active = false;
+  context.ui_state.debug_menu_modal_pushed = false;
   context.ui_state.debug_menu_selection = 0;
+  context.ui_state.error_popup_modal_pushed = false;
+  context.ui_state.register_host_modal_pushed = false;
 
   load_psn_id_if_needed();
 
@@ -590,15 +593,17 @@ void draw_ui() {
           // Handle modal focus for PIN entry screen only
           // Connection screens (WAKING/RECONNECTING) are handled by ui_state.c
           // Pop modal when leaving PIN entry screen
-          if (prev_screen == UI_SCREEN_TYPE_REGISTER_HOST) {
-            if (ui_focus_has_modal()) {
-              ui_focus_pop_modal();
-            }
+          if (prev_screen == UI_SCREEN_TYPE_REGISTER_HOST &&
+              context.ui_state.register_host_modal_pushed) {
+            ui_focus_pop_modal();
+            context.ui_state.register_host_modal_pushed = false;
           }
 
           // Push modal when entering PIN entry screen
-          if (next_screen == UI_SCREEN_TYPE_REGISTER_HOST) {
+          if (next_screen == UI_SCREEN_TYPE_REGISTER_HOST &&
+              !context.ui_state.register_host_modal_pushed) {
             ui_focus_push_modal();
+            context.ui_state.register_host_modal_pushed = true;
           }
         }
         screen = next_screen;

--- a/vita/src/ui/ui_components.c
+++ b/vita/src/ui/ui_components.c
@@ -313,8 +313,11 @@ void ui_error_show(const char* message) {
         context.ui_state.error_popup_text[0] = '\0';
     }
 
-    // Push modal focus to trap navigation
-    ui_focus_push_modal();
+    // Push modal focus once per popup activation.
+    if (!context.ui_state.error_popup_modal_pushed) {
+        ui_focus_push_modal();
+        context.ui_state.error_popup_modal_pushed = true;
+    }
 }
 
 /**
@@ -324,9 +327,10 @@ void ui_error_hide(void) {
   context.ui_state.error_popup_active = false;
   context.ui_state.error_popup_text[0] = '\0';
 
-  // Pop modal focus to restore navigation
-  if (ui_focus_has_modal()) {
+  // Pop only if this popup owns a modal push.
+  if (context.ui_state.error_popup_modal_pushed) {
     ui_focus_pop_modal();
+    context.ui_state.error_popup_modal_pushed = false;
   }
 }
 
@@ -555,8 +559,11 @@ void ui_debug_open(void) {
     *button_block_mask |= context.ui_state.button_state;
     *touch_block_active = true;
 
-    // Push modal focus to trap navigation
-    ui_focus_push_modal();
+    // Push modal focus once per debug menu activation.
+    if (!context.ui_state.debug_menu_modal_pushed) {
+        ui_focus_push_modal();
+        context.ui_state.debug_menu_modal_pushed = true;
+    }
 }
 
 /**
@@ -575,9 +582,10 @@ void ui_debug_close(void) {
     *button_block_mask |= context.ui_state.button_state;
     *touch_block_active = true;
 
-  // Pop modal focus to restore navigation
-  if (ui_focus_has_modal()) {
+  // Pop only if this menu owns a modal push.
+  if (context.ui_state.debug_menu_modal_pushed) {
     ui_focus_pop_modal();
+    context.ui_state.debug_menu_modal_pushed = false;
   }
 }
 

--- a/vita/src/ui/ui_state.c
+++ b/vita/src/ui/ui_state.c
@@ -119,8 +119,8 @@ void ui_connection_complete(void) {
   waking_start_time = 0;
   waking_wait_for_stream_us = 0;
 
-  // Pop modal focus only if we actually pushed (check if we're in modal state)
-  if (connection_overlay_modal_pushed && ui_focus_has_modal()) {
+  // Pop modal focus only if this overlay owns a modal push.
+  if (connection_overlay_modal_pushed) {
     ui_focus_pop_modal();
   }
   connection_overlay_modal_pushed = false;
@@ -139,8 +139,8 @@ void ui_connection_cancel(void) {
     connection_thread_id = -1;
   }
 
-  // Pop modal focus only if we actually pushed (check if we're in modal state)
-  if (connection_overlay_modal_pushed && ui_focus_has_modal()) {
+  // Pop modal focus only if this overlay owns a modal push.
+  if (connection_overlay_modal_pushed) {
     ui_focus_pop_modal();
   }
   connection_overlay_modal_pushed = false;


### PR DESCRIPTION
Summary
- refactor modal lifecycle to explicit ownership flags instead of defensive has-modal checks at pop sites
- add UI state flags for modal ownership: error popup, debug menu, and register-host flow
- update Register Host screen transition handling to push/pop modal exactly once per flow
- update Error Popup and Debug Menu open/close paths to pop only when they own the modal push
- simplify Connection Overlay teardown paths to rely on its ownership flag

Why
- addresses review feedback about duplicated defensive checks and unclear modal ownership
- preserves safety while making push/pop pairing deterministic and easier to reason about

Validation
- built successfully with ./tools/build.sh debug