### PR TITLE
Unify stream stability path and remove recovery-profile toggle

### DIFF
--- a/docs/ai/LOGGING.md
+++ b/docs/ai/LOGGING.md
@@ -18,6 +18,11 @@ Use `.env` files in the repo root to seed compile-time defaults. The build scrip
 ./tools/build.sh --env-file /path/to/custom.env
 ```
 
+Important command behavior:
+- `./tools/build.sh` and `./tools/build.sh debug` produce installable `.vpk` outputs.
+- `./tools/build.sh test` only builds the `vitarps5_tests` binary and does not produce/update a `.vpk`.
+- If your on-device behavior changed, verify you installed a fresh VPK from a `build`/`debug` command rather than a `test` command.
+
 Supported keys inside `.env.*`:
 
 | Variable | Purpose | Example |
@@ -51,6 +56,7 @@ Even if `enabled = false`, the worker always writes `CHIAKI_LOG_ERROR` and `LOGE
 - Default output file: `ux0:data/vita-chiaki/vitarps5.log` (configurable via `.env` or `[logging].path`).
 - Pull the file from VitaShell (`ux0:/data/vita-chiaki/`) instead of copying console text.
 - The logging worker (`VitaLogThread`) buffers writes through a fixed queue (default 64) to avoid blocking Chiaki threads; bump `queue_depth` in verbose builds if you see drops.
+- For A/B stability runs, prefer `./tools/build.sh --env testing` so logs are written to `ux0:data/vita-chiaki/vitarps5-testing.log` with verbose transport markers.
 
 ## Adding New Logs
 - Prefer the existing `LOGD`/`LOGE` macros (`vita/include/context.h`). They route through the shared worker and honor the active profile.

--- a/docs/ai/STABILITY_AB_TESTING_GUIDE.md
+++ b/docs/ai/STABILITY_AB_TESTING_GUIDE.md
@@ -1,0 +1,78 @@
+# Stability A/B Testing Guide (Vitaki vs VitaRPS5)
+
+Last Updated: 2026-02-15
+Owner: Streaming/Latency track
+
+## Purpose
+Provide a repeatable process to compare VitaRPS5 streaming stability against Vitaki baseline and explain why one run may look grainy/choppy while another looks clean and stable.
+
+## Critical Distinction: Build Commands
+- `./tools/build.sh --env testing` builds a testing-profile VPK and should be used for on-device streaming validation.
+- `./tools/build.sh` builds a production-profile VPK.
+- `./tools/build.sh debug` builds a debug VPK.
+- `./tools/build.sh test` does not build a VPK; it only compiles `vitarps5_tests`.
+
+If a "new" test appears to change behavior after running `test`, verify that a different VPK was actually installed.
+
+## Stable Recovery Controls
+In `ux0:data/vita-chiaki/chiaki.toml`:
+
+```toml
+[settings]
+latency_mode = "balanced"
+```
+
+Behavior:
+- Startup bitrate follows the preset profile path (`preset_default` log marker).
+- Recovery path is fixed to the stable default (no runtime `stability_profile` switch).
+
+## A/B Procedure
+1. Build/install comparison candidate:
+- For reproducible logging: `./tools/build.sh --env testing`
+- Install generated VPK to Vita.
+
+2. Run identical test scenario for both apps:
+- Same console, same network, same game/scene, similar duration (at least 5 minutes).
+- Avoid changing router or Wi-Fi position between runs.
+
+3. Pull log file:
+- `ux0:data/vita-chiaki/vitarps5-testing.log` (testing profile)
+- Rename with timestamp after each run.
+
+4. Verify profile markers:
+- `Config loaded: latency_mode=...`
+- `Bitrate policy: ...`
+- `Recovery profile: ...`
+- `Video gap profile: ...`
+
+5. Compare health indicators:
+- `PIPE/FPS`: incoming/display FPS behavior over time.
+- `AV diag`: `missing_ref`, `corrupt_bursts`, `fec_fail`, `sendbuf_overflow`.
+- Disconnect/restart events: `PIPE/RECOVER`, `request_stream_stop`, reconnect loops.
+
+## Pass/Fail Heuristics
+Stable/good run (expected from stable default):
+- Markers:
+  - `Bitrate policy: preset_default (...)`
+  - `Recovery profile: stable_default`
+  - `Video gap profile: stable_default (hold_ms=24 force_span=12)`
+- `PIPE/FPS` stays around 30 target with no sustained low-FPS windows.
+- `AV diag` repeatedly shows zero for `missing_ref`, `corrupt_bursts`, `fec_fail`.
+- No repeated disconnects/reconnects.
+
+Degraded run signature:
+- Rising `missing_ref` and/or `corrupt_bursts` across windows.
+- Frequent low `PIPE/FPS` windows (<24 for long periods).
+- Recovery escalation loops or stream stops.
+
+## Known Good Reference
+`31595612449_vitarps5-testing.log` showed a good baseline-compatible run:
+- `Bitrate policy: preset_default (6000 kbps @ 960x540)`
+- `Recovery profile: stable_default`
+- `Video gap profile: stable_default (hold_ms=24 force_span=12)`
+- Repeated `AV diag` windows with `missing_ref=0, corrupt_bursts=0, fec_fail=0`.
+
+## Interpretation Guidance
+- If visuals are grainy/choppy but connection does not drop, prioritize packet/dependency diagnostics (`missing_ref`, `corrupt_bursts`) before decode-speed assumptions.
+- Recovery behavior is fixed to the stable default path; focus A/B on network conditions/build profile instead of config toggles.
+- If both branches look identical despite config edits, confirm log file path and active build profile first.

--- a/vita/src/config.c
+++ b/vita/src/config.c
@@ -820,6 +820,12 @@ void config_parse(VitaChiakiConfig* cfg) {
       }
     }
   }
+
+  LOGD("Config loaded: latency_mode=%s force_30fps=%s send_actual_start_bitrate=%s clamp_soft_restart_bitrate=%s",
+       serialize_latency_mode(cfg->latency_mode),
+       cfg->force_30fps ? "true" : "false",
+       cfg->send_actual_start_bitrate ? "true" : "false",
+       cfg->clamp_soft_restart_bitrate ? "true" : "false");
 }
 
 void config_free(VitaChiakiConfig* cfg) {


### PR DESCRIPTION
## Summary
- Collapse recovery behavior to a single stable default path based on the successful Vitaki-like run profile
- Remove runtime stability profile toggle plumbing from config and session code
- Keep preset startup bitrate policy and conservative recovery and gap behavior as the only path
- Update docs with the new single-path behavior and A/B validation markers

## Code changes
- vita/src/host.c: always use preset_default bitrate policy; simplify loss and unrecovered handling to non-escalating resync behavior
- lib/src/videoreceiver.c: make stable gap thresholds unconditional (hold_ms=24, force_span=12), keep missing-ref handling passive, request IDR only on hard FEC failures
- vita/src/config.c: remove stability_profile parse and serialize and logging surface

## Docs
- README.md: remove profile toggle guidance and document single stable path
- docs/ai/STREAM_PIPELINE_ROBUSTNESS_PLAN.md: record decision to keep one stable path
- docs/ai/STABILITY_AB_TESTING_GUIDE.md: update A/B procedure and log markers

## Validation
- ./tools/build.sh --env testing succeeded and produced VitakiForkv0.1.544.vpk
- ./tools/build.sh test continues to build tests independently of VPK output
