### PR TITLE
holepunch: bundled hardening follow-ups (#111, #112, #113)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,28 @@
+# gitleaks configuration for vitarps5
+#
+# Allowlists the public, reverse-engineered PS App OAuth client credentials that
+# are intentionally committed to this repository. See docs/ai/PSN_OAUTH_CREDENTIALS.md
+# for the full justification.
+#
+# These are NOT secrets. They identify the client application to Sony's OAuth
+# endpoint and are freely available across the open-source Remote Play ecosystem
+# (Chiaki, chiaki-ng, chiaki4deck, and derivatives). Removing them would only
+# break the build.
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Public PS-App OAuth client credentials (see docs/ai/PSN_OAUTH_CREDENTIALS.md)"
+
+paths = [
+    '''\.env\.prod$''',
+    '''\.env\.testing$''',
+    '''docs/ai/PSN_OAUTH_CREDENTIALS\.md$''',
+    '''vita/src/psn_auth\.c$''',
+]
+
+regexes = [
+    '''ba495a24-818c-472b-b12d-ff231c1b5745''',
+    '''mvaiZkRsAsI1IBkY''',
+]

--- a/docs/ai/PSN_OAUTH_CREDENTIALS.md
+++ b/docs/ai/PSN_OAUTH_CREDENTIALS.md
@@ -34,3 +34,19 @@ values as part of its PSN authentication support.
 Do not rotate, redact, or scrub these values on the assumption that they are
 accidental credential leaks. They are public, widely known values documented
 here deliberately.
+
+## Secret scanners
+
+A `.gitleaks.toml` config lives at the repo root that allowlists these values
+so `gitleaks detect` does not flag them. It inherits the gitleaks default
+ruleset (`extend.useDefault = true`) and adds a global allowlist covering:
+
+- Paths: `.env.prod`, `.env.testing`, `docs/ai/PSN_OAUTH_CREDENTIALS.md`, and
+  `vita/src/psn_auth.c`.
+- Regexes: the literal client ID `ba495a24-818c-472b-b12d-ff231c1b5745` and
+  the literal client secret `mvaiZkRsAsI1IBkY`.
+
+If you run a different scanner (trufflehog, git-secrets, detect-secrets, etc.),
+mirror this allowlist in that tool's configuration. Do NOT rotate, redact, or
+remove the values to silence a scanner — see the "Do NOT treat these as
+secrets" section above for why.

--- a/lib/src/remote/holepunch.c
+++ b/lib/src/remote/holepunch.c
@@ -2263,7 +2263,11 @@ static void* websocket_thread_func(void *user) {
 } while (0)
 
     char ws_url[128] = {0};
-    snprintf(ws_url, sizeof(ws_url), "wss://%s/np/pushNotification", session->ws_fqdn);
+    int _n = snprintf(ws_url, sizeof(ws_url), "wss://%s/np/pushNotification", session->ws_fqdn);
+    if (_n < 0 || (size_t)_n >= sizeof(ws_url)) {
+        CHIAKI_LOGE(session->log, "websocket_thread_func: ws_url truncated for fqdn=%s", session->ws_fqdn ? session->ws_fqdn : "(null)");
+        return NULL;
+    }
 
     CURL* curl = curl_easy_init();
     if(!curl)

--- a/lib/src/remote/holepunch.c
+++ b/lib/src/remote/holepunch.c
@@ -2267,6 +2267,9 @@ static void* websocket_thread_func(void *user) {
         goto fail_before_curl;
     }
 
+    /* 128 bytes fits wss:// + FQDN + /np/pushNotification + NUL for any FQDN up to
+     * ~101 chars. Sony's production push-notification FQDN is well under that; the
+     * snprintf truncation guard below will log and fail cleanly if it ever grows. */
     char ws_url[128] = {0};
     int url_len = snprintf(ws_url, sizeof(ws_url), "wss://%s/np/pushNotification", session->ws_fqdn);
     if (url_len < 0 || (size_t)url_len >= sizeof(ws_url)) {
@@ -2561,15 +2564,25 @@ cleanup:
      * deadlock waiting on state_cond. */
 fail_before_curl:
     {
-        ChiakiErrorCode _err = chiaki_mutex_lock(&session->state_mutex);
-        assert(_err == CHIAKI_ERR_SUCCESS);
+        /* This label is the deadlock-prevention path. Do not use assert() for the
+         * mutex/cond ops here: asserts compile away under NDEBUG and a silent failure
+         * would leave state_cond unsignalled, hanging the creator thread. */
+        ChiakiErrorCode mutex_err = chiaki_mutex_lock(&session->state_mutex);
+        if (mutex_err != CHIAKI_ERR_SUCCESS) {
+            CHIAKI_LOGE(session->log, "fail_before_curl: chiaki_mutex_lock failed (%d); caller may hang", mutex_err);
+            return NULL;
+        }
         session->ws_connect_err = CHIAKI_ERR_UNKNOWN;
         session->state |= SESSION_STATE_WS_FAILED;
         log_session_state(session);
-        _err = chiaki_cond_signal(&session->state_cond);
-        assert(_err == CHIAKI_ERR_SUCCESS);
-        _err = chiaki_mutex_unlock(&session->state_mutex);
-        assert(_err == CHIAKI_ERR_SUCCESS);
+        ChiakiErrorCode signal_err = chiaki_cond_signal(&session->state_cond);
+        if (signal_err != CHIAKI_ERR_SUCCESS) {
+            CHIAKI_LOGE(session->log, "fail_before_curl: chiaki_cond_signal failed (%d); caller may hang", signal_err);
+        }
+        ChiakiErrorCode unlock_err = chiaki_mutex_unlock(&session->state_mutex);
+        if (unlock_err != CHIAKI_ERR_SUCCESS) {
+            CHIAKI_LOGE(session->log, "fail_before_curl: chiaki_mutex_unlock failed (%d)", unlock_err);
+        }
         return NULL;
     }
 }
@@ -5991,6 +6004,8 @@ static ChiakiErrorCode get_stun_servers(Session *session)
                           sizeof(server_strings[0]), "%s", ptr);
         if (entry_len < 0 || (size_t)entry_len >= sizeof(server_strings[0])) {
             CHIAKI_LOGW(session->log, "STUN server entry truncated, skipping");
+        } else if (entry_len == 0) {
+            CHIAKI_LOGW(session->log, "STUN server entry empty, skipping");
         } else {
             session->num_stun_servers++;
         }
@@ -6065,8 +6080,8 @@ static ChiakiErrorCode get_stun_servers(Session *session)
         }
         goto cleanup;
     }
-    // ipv6 string has max of 45 chars: 39 chars + 2 chars for [] + 1 char for colon : + port has max of 4 chars + 1 char for null termination
-    char server_strings_ipv6[10][47];
+    // ipv6 string has max of 46 chars: 39 chars for addr + 2 chars for [] + 1 char for colon : + port has max of 5 chars (65535) + 1 char for null termination
+    char server_strings_ipv6[10][48];
     ptr = strtok(response_data.data, "\n");
     while(ptr != NULL && session->num_stun_servers_ipv6 <= 9)
     {
@@ -6075,6 +6090,8 @@ static ChiakiErrorCode get_stun_servers(Session *session)
                           sizeof(server_strings_ipv6[0]), "%s", ptr + 1);
         if (entry_len < 0 || (size_t)entry_len >= sizeof(server_strings_ipv6[0])) {
             CHIAKI_LOGW(session->log, "IPv6 STUN server entry truncated, skipping");
+        } else if (entry_len == 0) {
+            CHIAKI_LOGW(session->log, "IPv6 STUN server entry empty, skipping");
         } else {
             session->num_stun_servers_ipv6++;
         }

--- a/lib/src/remote/holepunch.c
+++ b/lib/src/remote/holepunch.c
@@ -5964,8 +5964,13 @@ static ChiakiErrorCode get_stun_servers(Session *session)
     char *ptr = strtok(response_data.data, "\n");
     while(ptr != NULL && session->num_stun_servers <= 9)
     {
-        strcpy(server_strings[session->num_stun_servers], ptr);
-        session->num_stun_servers++;
+        int _n = snprintf(server_strings[session->num_stun_servers],
+                          sizeof(server_strings[0]), "%s", ptr);
+        if (_n < 0 || (size_t)_n >= sizeof(server_strings[0])) {
+            CHIAKI_LOGW(session->log, "STUN server entry truncated, skipping");
+        } else {
+            session->num_stun_servers++;
+        }
 		ptr = strtok(NULL, "\n");
     }
     ptr = NULL;
@@ -6043,8 +6048,13 @@ static ChiakiErrorCode get_stun_servers(Session *session)
     while(ptr != NULL && session->num_stun_servers_ipv6 <= 9)
     {
         // omit leading [
-        strcpy(server_strings_ipv6[session->num_stun_servers_ipv6], ptr + 1);
-        session->num_stun_servers_ipv6++;
+        int _n = snprintf(server_strings_ipv6[session->num_stun_servers_ipv6],
+                          sizeof(server_strings_ipv6[0]), "%s", ptr + 1);
+        if (_n < 0 || (size_t)_n >= sizeof(server_strings_ipv6[0])) {
+            CHIAKI_LOGW(session->log, "IPv6 STUN server entry truncated, skipping");
+        } else {
+            session->num_stun_servers_ipv6++;
+        }
 		ptr = strtok(NULL, "\n");
     }
     ptr = NULL;

--- a/lib/src/remote/holepunch.c
+++ b/lib/src/remote/holepunch.c
@@ -2262,18 +2262,23 @@ static void* websocket_thread_func(void *user) {
     headers = _tmp; \
 } while (0)
 
+    if (!session->ws_fqdn) {
+        CHIAKI_LOGE(session->log, "websocket_thread_func: session->ws_fqdn is NULL");
+        goto fail_before_curl;
+    }
+
     char ws_url[128] = {0};
-    int _n = snprintf(ws_url, sizeof(ws_url), "wss://%s/np/pushNotification", session->ws_fqdn);
-    if (_n < 0 || (size_t)_n >= sizeof(ws_url)) {
-        CHIAKI_LOGE(session->log, "websocket_thread_func: ws_url truncated for fqdn=%s", session->ws_fqdn ? session->ws_fqdn : "(null)");
-        return NULL;
+    int url_len = snprintf(ws_url, sizeof(ws_url), "wss://%s/np/pushNotification", session->ws_fqdn);
+    if (url_len < 0 || (size_t)url_len >= sizeof(ws_url)) {
+        CHIAKI_LOGE(session->log, "websocket_thread_func: ws_url truncated for fqdn=%s", session->ws_fqdn);
+        goto fail_before_curl;
     }
 
     CURL* curl = curl_easy_init();
     if(!curl)
     {
         CHIAKI_LOGE(session->log, "Curl could not init");
-        return NULL;
+        goto fail_before_curl;
     }
     curl_apply_platform_tls_defaults(curl);
     struct curl_slist *headers = NULL;
@@ -2549,6 +2554,24 @@ cleanup:
 #undef APPEND_WS_HEADER
 
     return NULL;
+
+    /* Reached only via goto when curl/headers have not been initialized yet
+     * (NULL ws_fqdn, url truncation, or curl_easy_init failure). Signal
+     * SESSION_STATE_WS_FAILED so chiaki_holepunch_session_create does not
+     * deadlock waiting on state_cond. */
+fail_before_curl:
+    {
+        ChiakiErrorCode _err = chiaki_mutex_lock(&session->state_mutex);
+        assert(_err == CHIAKI_ERR_SUCCESS);
+        session->ws_connect_err = CHIAKI_ERR_UNKNOWN;
+        session->state |= SESSION_STATE_WS_FAILED;
+        log_session_state(session);
+        _err = chiaki_cond_signal(&session->state_cond);
+        assert(_err == CHIAKI_ERR_SUCCESS);
+        _err = chiaki_mutex_unlock(&session->state_mutex);
+        assert(_err == CHIAKI_ERR_SUCCESS);
+        return NULL;
+    }
 }
 
 static NotificationType parse_notification_type(
@@ -5959,14 +5982,14 @@ static ChiakiErrorCode get_stun_servers(Session *session)
         }
         goto cleanup;
     }
-    // hostname has max of 253 chars + 1 char for colon : + port has max of 4 chars + 1 char for null termination
-    char server_strings[10][259];
+    // hostname has max of 253 chars + 1 char for colon : + port has max of 5 chars (65535) + 1 char for null termination
+    char server_strings[10][260];
     char *ptr = strtok(response_data.data, "\n");
     while(ptr != NULL && session->num_stun_servers <= 9)
     {
-        int _n = snprintf(server_strings[session->num_stun_servers],
+        int entry_len = snprintf(server_strings[session->num_stun_servers],
                           sizeof(server_strings[0]), "%s", ptr);
-        if (_n < 0 || (size_t)_n >= sizeof(server_strings[0])) {
+        if (entry_len < 0 || (size_t)entry_len >= sizeof(server_strings[0])) {
             CHIAKI_LOGW(session->log, "STUN server entry truncated, skipping");
         } else {
             session->num_stun_servers++;
@@ -6048,9 +6071,9 @@ static ChiakiErrorCode get_stun_servers(Session *session)
     while(ptr != NULL && session->num_stun_servers_ipv6 <= 9)
     {
         // omit leading [
-        int _n = snprintf(server_strings_ipv6[session->num_stun_servers_ipv6],
+        int entry_len = snprintf(server_strings_ipv6[session->num_stun_servers_ipv6],
                           sizeof(server_strings_ipv6[0]), "%s", ptr + 1);
-        if (_n < 0 || (size_t)_n >= sizeof(server_strings_ipv6[0])) {
+        if (entry_len < 0 || (size_t)entry_len >= sizeof(server_strings_ipv6[0])) {
             CHIAKI_LOGW(session->log, "IPv6 STUN server entry truncated, skipping");
         } else {
             session->num_stun_servers_ipv6++;


### PR DESCRIPTION
## Summary

Bundles three follow-up hardening items from the PR #108 review into one PR.

- **#111** — Guard `ws_url` snprintf against truncation in `websocket_thread_func`. Matches the existing `APPEND_WS_HEADER` pattern. Bails out cleanly via a new `fail_before_curl` label that signals `SESSION_STATE_WS_FAILED` so the creator thread can't deadlock.
- **#112** — Bounds-check STUN server list parsing: replace unchecked `strcpy` with `snprintf` in both the IPv4 (260-byte slot, 5-digit port) and IPv6 (48-byte slot, 5-digit port) fetch paths. Oversized and empty entries are logged and skipped. Non-Vita path only; Vita short-circuits per #108.
- **#113** — Add `.gitleaks.toml` allowlisting the public PS-App OAuth client values committed in `.env.prod` / `.env.testing` / `docs/ai/PSN_OAUTH_CREDENTIALS.md` / `vita/src/psn_auth.c`, plus a "Secret scanners" section in the credentials doc.

Each ticket lands as its own commit with a `Fixes #N` trailer; two follow-up commits on top address the Copilot and Claude reviews (NULL-guard on `ws_fqdn`, deadlock signalling for all pre-curl-init exits, IPv4/IPv6 buffer sizing for 5-digit ports, empty-entry skip, asserts → explicit error logs in the deadlock-prevention label).

## Test plan

- [x] `./tools/build.sh --env testing` — green after #111
- [x] `./tools/build.sh --env testing` — green after #112
- [x] `./tools/build.sh --env testing` — green after #113 (no-op for build; config + docs)
- [x] `./tools/build.sh --env testing` — green after Copilot fixes (deadlock signalling, NULL guard, port sizing)
- [x] `./tools/build.sh --env testing` — green after Claude fixes (explicit error logs, empty-entry guard, IPv6 port sizing)
- [x] clang-format + cppcheck gate scoped to `vita/` per PR #107 — `lib/` untouched by gate; existing style in holepunch.c preserved