### PR TITLE
fix(ui): PR #121 follow-up cleanup (#129)

### DIFF
--- a/vita/src/ui/ui_screens.c
+++ b/vita/src/ui/ui_screens.c
@@ -1395,7 +1395,9 @@ static void draw_connection_info_card(int x, int y, int width, int height, bool 
       cy += body_line_h;
     }
   } else {
-    /* Idle: Status + Quality only */
+    /* Idle: Status + Quality only.
+     * Quality is intentionally rendered here and not in the streaming branches
+     * above — the in-stream view is deliberately compact.  Do not mirror it. */
     const char *status_text;
     if (has_host && !has_registered) {
       status_text = "Ready / Not Registered";
@@ -1714,12 +1716,10 @@ UIScreenType ui_screen_draw_profile(void) {
         s_logout_confirm_until_us = now_us_cross + 3000000ULL;
       }
     } else {
-      /* Card body focus (or disabled button): existing login/refresh flow. */
-      if (profile_state.connection_focus == CONN_FOCUS_LOGOUT_BTN) {
-        /* Button focused but disabled — clear stale confirm and return focus */
-        profile_state.connection_focus = CONN_FOCUS_CARD;
-        s_logout_confirm_until_us = 0;
-      }
+      /* Card body focus: existing login/refresh flow.
+       * Invariant: connection_focus == CONN_FOCUS_CARD here — the safety snap
+       * above clears LOGOUT_BTN focus whenever the button is disabled, which
+       * matches the precondition of this else branch. */
       if (!psn_auth_enabled()) {
         trigger_hints_popup("PSN internet mode is disabled in Settings");
       } else if (psn_auth_device_login_active()) {

--- a/vita/src/ui/ui_screens.c
+++ b/vita/src/ui/ui_screens.c
@@ -1397,7 +1397,7 @@ static void draw_connection_info_card(int x, int y, int width, int height, bool 
   } else {
     /* Idle: Status + Quality only.
      * Quality is intentionally rendered here and not in the streaming branches
-     * above — the in-stream view is deliberately compact.  Do not mirror it. */
+     * above — the in-stream view is deliberately compact. Do not mirror it. */
     const char *status_text;
     if (has_host && !has_registered) {
       status_text = "Ready / Not Registered";
@@ -1717,9 +1717,10 @@ UIScreenType ui_screen_draw_profile(void) {
       }
     } else {
       /* Card body focus: existing login/refresh flow.
-       * Invariant: connection_focus == CONN_FOCUS_CARD here — the safety snap
-       * above clears LOGOUT_BTN focus whenever the button is disabled, which
-       * matches the precondition of this else branch. */
+       * Invariant: connection_focus == CONN_FOCUS_CARD here — earlier safety
+       * logic snaps focus away from LOGOUT_BTN whenever the logout button
+       * becomes disabled, so reaching this path never requires logout-button
+       * focus to remain active. */
       if (!psn_auth_enabled()) {
         trigger_hints_popup("PSN internet mode is disabled in Settings");
       } else if (psn_auth_device_login_active()) {


### PR DESCRIPTION
## Summary
Addresses items 1 and 3 of #129 (PR #121 Round 6 review polish).

- **Item 1** — Remove dead defensive focus reset in the CROSS `else` branch at `vita/src/ui/ui_screens.c:1716`. The safety snap at ~L1654 already resets `connection_focus` to `CONN_FOCUS_CARD` whenever `!(psn_auth_enabled() && s_logout_psn_valid)`, which is exactly the condition required to reach this `else`. Replaced with an invariant comment.
- **Item 3** — Expand the idle-branch comment in `draw_connection_info_card` to document that Quality is intentionally rendered only on the idle branch; the in-stream view is deliberately compact.

Comment / dead-code only — no behavior change.

### Deferred
- Item 2 (suspend/resume touch state): conditional on a future suspend hook landing; no such hook exists today.
- Item 4 (`console_name`/`console_ip` duplication): overlaps with open bug #94; better addressed there.

## Test plan
- [ ] `./tools/build.sh --env testing` builds clean
- [ ] Profile screen: with PSN logged in, CROSS on Log out button still triggers confirm-then-execute
- [ ] Profile screen: with PSN logged out, CROSS on card body still triggers existing login flow
- [ ] Connection card: idle shows Quality row; streaming shows compact "Status: Streaming"

Refs #129. cc #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)