### PR TITLE
fix(net): SO_SNDBUF symmetric tuning + Senkusha 1ms RTT fallback fix

### DIFF
--- a/lib/src/session.c
+++ b/lib/src/session.c
@@ -669,7 +669,9 @@ ctrl_failed:
 			CHIAKI_LOGE(session->log, "Senkusha failed, but we still try to connect with fallback values");
 			session->mtu_in = 1454;
 			session->mtu_out = 1454;
-			session->rtt_us = 1000;
+			/* 5ms is a conservative LAN fallback; 1ms was a stale placeholder
+			 * that caused downstream timing decisions to be unrealistically tight. */
+			session->rtt_us = 5000;
 		}
 #endif
 		if(session->rudp)

--- a/lib/src/session.c
+++ b/lib/src/session.c
@@ -670,7 +670,9 @@ ctrl_failed:
 			session->mtu_in = 1454;
 			session->mtu_out = 1454;
 			/* 5ms is a conservative LAN fallback; 1ms was a stale placeholder
-			 * that caused downstream timing decisions to be unrealistically tight. */
+			 * that caused downstream timing decisions to be unrealistically tight.
+			 * TODO: PSN/relay paths probably want ~30000us — track per-session-type
+			 * fallback in a follow-up. */
 			session->rtt_us = 5000;
 		}
 #endif

--- a/lib/src/takion.c
+++ b/lib/src/takion.c
@@ -308,10 +308,14 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_takion_connect(ChiakiTakion *takion, Chiaki
 			r = setsockopt(takion->sock, SOL_SOCKET, SO_SNDBUF, (const CHIAKI_SOCKET_BUF_TYPE)&sndbuf_val, sizeof(sndbuf_val));
 			if(r < 0)
 			{
-				CHIAKI_LOGE(takion->log, "Takion failed to setsockopt SO_SNDBUF: " CHIAKI_SOCKET_ERROR_FMT, CHIAKI_SOCKET_ERROR_VALUE);
-				ret = CHIAKI_ERR_NETWORK;
-				goto error_sock;
+				/* SO_SNDBUF is a performance hint, not required for correctness;
+				 * the OS default send buffer is still usable. Locked-down kernels
+				 * (e.g. low net.core.wmem_max) can fail this with EPERM, in which
+				 * case we'd rather stream with a smaller send buffer than refuse
+				 * to connect. */
+				CHIAKI_LOGW(takion->log, "Takion failed to setsockopt SO_SNDBUF (non-fatal): " CHIAKI_SOCKET_ERROR_FMT, CHIAKI_SOCKET_ERROR_VALUE);
 			}
+			else
 			{
 				int actual_sndbuf = 0;
 				socklen_t optlen = sizeof(actual_sndbuf);
@@ -425,10 +429,14 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_takion_connect(ChiakiTakion *takion, Chiaki
 			r = setsockopt(takion->sock, SOL_SOCKET, SO_SNDBUF, (const CHIAKI_SOCKET_BUF_TYPE)&sndbuf_val, sizeof(sndbuf_val));
 			if(r < 0)
 			{
-				CHIAKI_LOGE(takion->log, "Takion failed to setsockopt SO_SNDBUF: " CHIAKI_SOCKET_ERROR_FMT, CHIAKI_SOCKET_ERROR_VALUE);
-				ret = CHIAKI_ERR_NETWORK;
-				goto error_sock;
+				/* SO_SNDBUF is a performance hint, not required for correctness;
+				 * the OS default send buffer is still usable. Locked-down kernels
+				 * (e.g. low net.core.wmem_max) can fail this with EPERM, in which
+				 * case we'd rather stream with a smaller send buffer than refuse
+				 * to connect. */
+				CHIAKI_LOGW(takion->log, "Takion failed to setsockopt SO_SNDBUF (non-fatal): " CHIAKI_SOCKET_ERROR_FMT, CHIAKI_SOCKET_ERROR_VALUE);
 			}
+			else
 			{
 				int actual_sndbuf = 0;
 				socklen_t optlen = sizeof(actual_sndbuf);

--- a/lib/src/takion.c
+++ b/lib/src/takion.c
@@ -301,6 +301,24 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_takion_connect(ChiakiTakion *takion, Chiaki
 			if(getsockopt(takion->sock, SOL_SOCKET, SO_RCVBUF, (CHIAKI_SOCKET_BUF_TYPE)&actual_rcvbuf, &optlen) == 0)
 				CHIAKI_LOGI(takion->log, "Takion SO_RCVBUF requested=%d actual=%d", rcvbuf_val, actual_rcvbuf);
 		}
+		/* Match send buffer to receive buffer so IDR/feedback/ACK bursts are not
+		 * stalled by a tiny OS-default SO_SNDBUF. */
+		{
+			const int sndbuf_val = takion->a_rwnd;
+			r = setsockopt(takion->sock, SOL_SOCKET, SO_SNDBUF, (const CHIAKI_SOCKET_BUF_TYPE)&sndbuf_val, sizeof(sndbuf_val));
+			if(r < 0)
+			{
+				CHIAKI_LOGE(takion->log, "Takion failed to setsockopt SO_SNDBUF: " CHIAKI_SOCKET_ERROR_FMT, CHIAKI_SOCKET_ERROR_VALUE);
+				ret = CHIAKI_ERR_NETWORK;
+				goto error_sock;
+			}
+			{
+				int actual_sndbuf = 0;
+				socklen_t optlen = sizeof(actual_sndbuf);
+				if(getsockopt(takion->sock, SOL_SOCKET, SO_SNDBUF, (CHIAKI_SOCKET_BUF_TYPE)&actual_sndbuf, &optlen) == 0)
+					CHIAKI_LOGI(takion->log, "Takion SO_SNDBUF requested=%d actual=%d", sndbuf_val, actual_sndbuf);
+			}
+		}
 
 #if defined(__APPLE__)
 		SInt32 majorVersion;
@@ -399,6 +417,24 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_takion_connect(ChiakiTakion *takion, Chiaki
 			socklen_t optlen = sizeof(actual_rcvbuf);
 			if(getsockopt(takion->sock, SOL_SOCKET, SO_RCVBUF, (CHIAKI_SOCKET_BUF_TYPE)&actual_rcvbuf, &optlen) == 0)
 				CHIAKI_LOGI(takion->log, "Takion SO_RCVBUF requested=%d actual=%d", rcvbuf_val, actual_rcvbuf);
+		}
+		/* Match send buffer to receive buffer so IDR/feedback/ACK bursts are not
+		 * stalled by a tiny OS-default SO_SNDBUF. */
+		{
+			const int sndbuf_val = takion->a_rwnd;
+			r = setsockopt(takion->sock, SOL_SOCKET, SO_SNDBUF, (const CHIAKI_SOCKET_BUF_TYPE)&sndbuf_val, sizeof(sndbuf_val));
+			if(r < 0)
+			{
+				CHIAKI_LOGE(takion->log, "Takion failed to setsockopt SO_SNDBUF: " CHIAKI_SOCKET_ERROR_FMT, CHIAKI_SOCKET_ERROR_VALUE);
+				ret = CHIAKI_ERR_NETWORK;
+				goto error_sock;
+			}
+			{
+				int actual_sndbuf = 0;
+				socklen_t optlen = sizeof(actual_sndbuf);
+				if(getsockopt(takion->sock, SOL_SOCKET, SO_SNDBUF, (CHIAKI_SOCKET_BUF_TYPE)&actual_sndbuf, &optlen) == 0)
+					CHIAKI_LOGI(takion->log, "Takion SO_SNDBUF requested=%d actual=%d", sndbuf_val, actual_sndbuf);
+			}
 		}
 		if(info->ip_dontfrag)
 		{


### PR DESCRIPTION
## Summary

Two small network-layer fixes from the Remote Play Smoothness Initiative (`docs/ai/REMOTE_PLAY_SMOOTHNESS_PLAN.md`, T2 + T4).

- **T2 — Symmetric `SO_SNDBUF`** (`lib/src/takion.c`): The Takion UDP socket already set `SO_RCVBUF` to `TAKION_A_RWND` (512 KB on Vita) but left `SO_SNDBUF` at the OS default. A tiny default send buffer can stall IDR-request / feedback / ACK bursts — especially under packet loss when the client needs to fire multiple requests quickly. Now sets `SO_SNDBUF` to the same value on both socket paths (direct + PSN holepunch) with a `getsockopt` read-back log so we can see what the kernel actually granted.
- **T4 — Senkusha RTT fallback** (`lib/src/session.c`): `session->rtt_us` was hard-coded to `1000` (= 1 ms) when Senkusha fails. 1 ms is physically impossible on any real path and propagates into the LaunchSpec JSON (`rtt = 1`). Changed to `5000` (5 ms, a conservative LAN default). The code comment explains why.

## Test plan

- [ ] Build with `./tools/build.sh --env testing`
- [ ] Deploy and stream over LAN — confirm no regression in latency or stability
- [ ] Check `SO_SNDBUF requested=X actual=Y` log line appears on session start
- [ ] (Optional) Induce burst packet loss — verify IDR requests fire without stalling

## Notes

- T2 review flagged: PSN paths might benefit from a higher RTT fallback (~30 ms) in a follow-up, but 5 ms is safe and an improvement over 1 ms.
- T1 (CPU affinity split) was squash-merged into main as part of PR #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)