### PR TITLE
fix(build): replace -Dgai_strerror=strerror macro with netdb.h stub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,7 +106,7 @@ RUN cd /tmp && \
         -DUPNPC_BUILD_SAMPLE=OFF \
         -DNO_GETADDRINFO=ON \
         -DCMAKE_POSITION_INDEPENDENT_CODE=OFF \
-        -DCMAKE_C_FLAGS="-fno-pic -I/tmp/vita-stubs -Wno-error -Dgai_strerror=strerror -DNEED_STRUCT_IP_MREQN" \
+        -DCMAKE_C_FLAGS="-fno-pic -I/tmp/vita-stubs -Wno-error -DNEED_STRUCT_IP_MREQN" \
         -DCMAKE_BUILD_TYPE=Release && \
     make && \
     make install && \

--- a/third-party/vita-stubs/netdb.h
+++ b/third-party/vita-stubs/netdb.h
@@ -1,0 +1,27 @@
+/*
+ * vita-stubs/netdb.h — stub for gai_strerror on VitaSDK
+ *
+ * VitaSDK has no <netdb.h>.  miniupnpc calls gai_strerror() when
+ * NO_GETADDRINFO is NOT set, but older build systems worked around
+ * this with -Dgai_strerror=strerror.  That macro trick broke under
+ * GCC 15 because the textual replacement creates a conflicting
+ * redeclaration:
+ *
+ *   const char *strerror(int)   ← what POSIX gai_strerror returns
+ *   char       *strerror(int)   ← what VitaSDK string.h declares
+ *
+ * This inline wrapper satisfies the POSIX const char * return type
+ * while delegating to the SDK's strerror() via an explicit cast,
+ * with no conflicting declarations.
+ */
+#ifndef _VITA_STUBS_NETDB_H
+#define _VITA_STUBS_NETDB_H
+
+#include <string.h>
+
+static inline const char *gai_strerror(int ecode)
+{
+    return (const char *)strerror(ecode);
+}
+
+#endif /* _VITA_STUBS_NETDB_H */


### PR DESCRIPTION
## Summary
- GCC 15 (now in `vitasdk/vitasdk:latest`) hard-errors when `-Dgai_strerror=strerror` transforms a `const char *gai_strerror(int)` declaration into `const char *strerror(int)`, conflicting with VitaSDK's `char *strerror(int)` in `string.h:40`
- Adds `third-party/vita-stubs/netdb.h` with a `static inline gai_strerror()` wrapper that casts `strerror()` to `const char *`
- Removes the broken `-Dgai_strerror=strerror` flag from `Dockerfile` miniupnpc build step

## Test plan
- [ ] Run `./tools/build.sh --env testing` — Docker image must build successfully through the miniupnpc step
- [ ] Confirm VPK builds and deploys to Vita normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)