### PR TITLE
fix(build): complete GCC 15 compatibility for miniupnpc stub headers

### DIFF
--- a/third-party/vita-stubs/netdb.h
+++ b/third-party/vita-stubs/netdb.h
@@ -1,27 +1,40 @@
 /*
- * vita-stubs/netdb.h — stub for gai_strerror on VitaSDK
+ * vita-stubs/netdb.h — stub for missing POSIX network-name symbols on VitaSDK
  *
- * VitaSDK has no <netdb.h>.  miniupnpc calls gai_strerror() when
- * NO_GETADDRINFO is NOT set, but older build systems worked around
- * this with -Dgai_strerror=strerror.  That macro trick broke under
- * GCC 15 because the textual replacement creates a conflicting
- * redeclaration:
+ * VitaSDK has no <netdb.h>. Two sets of symbols are missing:
  *
- *   const char *strerror(int)   ← what POSIX gai_strerror returns
- *   char       *strerror(int)   ← what VitaSDK string.h declares
+ * 1. gai_strerror(): returns const char * — the -Dgai_strerror=strerror
+ *    macro trick broke under GCC 15 (conflicting const vs non-const return
+ *    type redeclaration of strerror). Replaced by this inline wrapper.
  *
- * This inline wrapper satisfies the POSIX const char * return type
- * while delegating to the SDK's strerror() via an explicit cast,
- * with no conflicting declarations.
+ * 2. getnameinfo() + NI_* flags: used by miniwget.c for debug logging.
+ *    The function is defined as a no-op in posix_stubs.c; the declaration
+ *    and flag constants are provided here so GCC 15 (which hard-errors on
+ *    implicit declarations) can compile the call sites.
  */
 #ifndef _VITA_STUBS_NETDB_H
 #define _VITA_STUBS_NETDB_H
 
 #include <string.h>
+#include <sys/socket.h>
 
+/* gai_strerror: map error code to string (used by miniupnpc.c) */
 static inline const char *gai_strerror(int ecode)
 {
     return (const char *)strerror(ecode);
 }
+
+/* NI_* flags for getnameinfo() — standard POSIX values */
+#define NI_NUMERICHOST  1
+#define NI_NUMERICSERV  2
+#define NI_NOFQDN       4
+#define NI_NAMEREQD     8
+#define NI_DGRAM        16
+
+/* getnameinfo: defined as a no-op in posix_stubs.c */
+int getnameinfo(const struct sockaddr *sa, socklen_t salen,
+                char *host, socklen_t hostlen,
+                char *serv, socklen_t servlen,
+                int flags);
 
 #endif /* _VITA_STUBS_NETDB_H */

--- a/third-party/vita-stubs/netdb.h
+++ b/third-party/vita-stubs/netdb.h
@@ -1,7 +1,7 @@
 /*
  * vita-stubs/netdb.h — stub for missing POSIX network-name symbols on VitaSDK
  *
- * VitaSDK has no <netdb.h>. Two sets of symbols are missing:
+ * VitaSDK has no <netdb.h>. The following symbols are missing:
  *
  * 1. gai_strerror(): returns const char * — the -Dgai_strerror=strerror
  *    macro trick broke under GCC 15 (conflicting const vs non-const return
@@ -11,6 +11,10 @@
  *    The function is defined as a no-op in posix_stubs.c; the declaration
  *    and flag constants are provided here so GCC 15 (which hard-errors on
  *    implicit declarations) can compile the call sites.
+ *
+ * 3. struct hostent + gethostbyname() + herror(): used by connecthostport.c
+ *    when NO_GETADDRINFO is defined (USE_GETHOSTBYNAME path). The struct and
+ *    declarations are provided here; stubs are in posix_stubs.c.
  */
 #ifndef _VITA_STUBS_NETDB_H
 #define _VITA_STUBS_NETDB_H
@@ -24,6 +28,8 @@ static inline const char *gai_strerror(int ecode)
     return (const char *)strerror(ecode);
 }
 
+/* ---- getnameinfo ---- */
+
 /* NI_* flags for getnameinfo() — standard POSIX values */
 #define NI_NUMERICHOST  1
 #define NI_NUMERICSERV  2
@@ -36,5 +42,27 @@ int getnameinfo(const struct sockaddr *sa, socklen_t salen,
                 char *host, socklen_t hostlen,
                 char *serv, socklen_t servlen,
                 int flags);
+
+/* ---- gethostbyname / struct hostent ---- */
+
+/*
+ * struct hostent: minimal definition sufficient for the USE_GETHOSTBYNAME
+ * code path in connecthostport.c, which only accesses hp->h_addr.
+ * h_addr is the traditional POSIX alias for h_addr_list[0].
+ */
+struct hostent {
+    char  *h_name;        /* official name of host */
+    char **h_aliases;     /* alias list */
+    int    h_addrtype;    /* host address type */
+    int    h_length;      /* length of address */
+    char **h_addr_list;   /* list of addresses from name server */
+};
+#define h_addr h_addr_list[0]
+
+/* gethostbyname: defined as a returning-NULL stub in posix_stubs.c */
+struct hostent *gethostbyname(const char *name);
+
+/* herror: defined as a no-op stub in posix_stubs.c */
+void herror(const char *s);
 
 #endif /* _VITA_STUBS_NETDB_H */

--- a/third-party/vita-stubs/posix_stubs.c
+++ b/third-party/vita-stubs/posix_stubs.c
@@ -10,6 +10,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <stddef.h>
+#include "netdb.h"
 
 /* in6addr_any: declared as extern in net/if.h; definition lives here to avoid
  * multiple-definition errors when net/if.h is included by multiple translation
@@ -36,4 +37,14 @@ int getnameinfo(const struct sockaddr *sa, socklen_t salen,
 void herror(const char *s)
 {
     (void)s;
+}
+
+/* gethostbyname: legacy DNS lookup, used in connecthostport when
+ * NO_GETADDRINFO / USE_GETHOSTBYNAME is defined.  VitaSDK provides no
+ * implementation; returning NULL causes the caller to invoke herror() and
+ * return INVALID_SOCKET — a safe failure for an unreachable code path. */
+struct hostent *gethostbyname(const char *name)
+{
+    (void)name;
+    return NULL;
 }


### PR DESCRIPTION
## Summary

Follows PR #151 which fixed the `gai_strerror` redeclaration error. After that fix the build progressed further and surfaced additional GCC 15 strictness failures in miniupnpc's `miniwget.c` and `connecthostport.c`. This PR resolves all of them so `./tools/build.sh --env testing` succeeds end-to-end.

**Root cause:** GCC 15 hard-errors on implicit function declarations and undeclared identifiers that older GCC silently accepted. VitaSDK has no `<netdb.h>`, so miniupnpc's call sites had no visible declarations.

**Fixes in `third-party/vita-stubs/netdb.h`:**
- Added `getnameinfo()` prototype (function body already existed in `posix_stubs.c`) + `NI_NUMERICHOST`, `NI_NUMERICSERV`, `NI_NOFQDN`, `NI_NAMEREQD`, `NI_DGRAM` constants — required by `miniwget.c`
- Added `struct hostent` layout, `gethostbyname()` declaration, and `herror()` declaration — required by `connecthostport.c` under `-DNO_GETADDRINFO=ON`

**Fixes in `third-party/vita-stubs/posix_stubs.c`:**
- Added `gethostbyname()` no-op stub (returns `NULL` → safe failure, code path not reached on Vita)
- Added `#include "netdb.h"` so stub definitions are consistent with declarations seen by other TUs

## Test plan
- [x] `./tools/build.sh --env testing` exits 0, produces `build/vitaki-fork.vpk` (v0.1.739)

🤖 Generated with [Claude Code](https://claude.com/claude-code)