### PR TITLE
fix(build): bump cmake_minimum_required to 3.5 for CMake 4.1 compat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Fix -rdynamic error with arm-vita-eabi-gcc https://github.com/tdlib/td/issues/1558
 if (POLICY CMP0065)

--- a/lib/src/discovery.c
+++ b/lib/src/discovery.c
@@ -175,7 +175,7 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_discovery_init(ChiakiDiscovery *discovery, 
 #ifndef __SWITCH__
 			struct in6_addr anyaddr = IN6ADDR_ANY_INIT;
 #endif
-			struct sockaddr_in6 *addr = &discovery->local_addr;
+			struct sockaddr_in6 *addr = (struct sockaddr_in6 *)&discovery->local_addr;
 // FIXME ywnico check if ok to leave out vita here
 #ifndef __SWITCH__
 			addr->sin6_addr = anyaddr;

--- a/lib/src/ffmpegdecoder.c
+++ b/lib/src/ffmpegdecoder.c
@@ -104,7 +104,6 @@ error_mutex:
 
 CHIAKI_EXPORT void chiaki_ffmpeg_decoder_fini(ChiakiFfmpegDecoder *decoder)
 {
-	avcodec_close(decoder->codec_context);
 	avcodec_free_context(&decoder->codec_context);
 	if(decoder->hw_device_ctx)
 		av_buffer_unref(&decoder->hw_device_ctx);

--- a/vita/include/message_log.h
+++ b/vita/include/message_log.h
@@ -10,8 +10,8 @@
 // A hard-wrapped message log
 typedef struct vita_chiaki_message_log_t {
   char log[MLOG_LINES + 1][MLOG_LINE_LEN + 1];
-  uint8_t start_offset;
-  uint8_t lines;
+  uint16_t start_offset;
+  uint16_t lines;
   uint64_t last_update;
 } VitaChiakiMessageLog;
 

--- a/vita/src/message_log.c
+++ b/vita/src/message_log.c
@@ -1,4 +1,5 @@
 #include "message_log.h"
+#include <psp2/kernel/processmgr.h>
 
 VitaChiakiMessageLog *message_log_create() {
   VitaChiakiMessageLog *ml = (VitaChiakiMessageLog *)malloc(sizeof(VitaChiakiMessageLog));

--- a/vita/src/video.c
+++ b/vita/src/video.c
@@ -210,6 +210,16 @@ typedef struct SceVideodecCtrl {
 extern SceInt32 sceVideodecQueryMemSize(SceUInt32 codecType,
                                         const SceVideodecQueryInitInfo *pInitInfo,
                                         SceVideodecMemInfo *pMemInfo);
+/* Extended videodec + codec-engine API not yet in VitaSDK headers (GCC 15
+ * hard-errors on implicit declarations; symbols exist in stub libs). */
+extern SceInt32 sceVideodecInitLibraryWithUnmapMem(SceVideodecType codec, SceVideodecCtrl *libCtrl,
+                                                   const SceVideodecQueryInitInfo *initInfo);
+extern SceUID sceCodecEngineOpenUnmapMemBlock(void *base, SceUInt32 size);
+extern SceInt32 sceCodecEngineCloseUnmapMemBlock(SceUID unmapUid);
+extern SceUIntVAddr sceCodecEngineAllocMemoryFromUnmapMemBlock(SceUID unmapUid, SceUInt32 size,
+                                                               SceUInt32 alignment);
+extern SceInt32 sceCodecEngineFreeMemoryFromUnmapMemBlock(SceUID unmapUid, SceUIntVAddr vaCtx);
+extern SceInt32 sceAvcdecDecodeAvailableSize(const SceAvcdecCtrl *decoder);
 
 SceAvcdecAu au = {0};
 SceAvcdecArrayPicture array_picture = {0};


### PR DESCRIPTION
## Summary

`vitasdk/vitasdk:latest` updated to CMake 4.1.3, which dropped backwards-compatibility support for `cmake_minimum_required VERSION < 3.5`. Fixing the configure error surfaced several more pre-existing build failures that were hidden behind it.

- **`CMakeLists.txt`** — `VERSION 3.2` → `VERSION 3.5` (the root cause)
- **`third-party/nanopb/CMakeLists.txt`** — same fix in the nanopb submodule (`VERSION 2.8.12` → `VERSION 3.5`)
- **`lib/src/discovery.c`** — explicit `(struct sockaddr_in6 *)` cast for GCC 15 incompatible-pointer error
- **`lib/src/ffmpegdecoder.c`** — remove `avcodec_close()` removed in FFmpeg 6+; `avcodec_free_context()` already handles cleanup
- **`vita/src/video.c`** — add 6 `extern` declarations for codec-engine / extended-videodec API missing from VitaSDK headers
- **`vita/src/message_log.c`** — add `#include <psp2/kernel/processmgr.h>` for `sceKernelGetProcessTimeWide`
- **`vita/include/message_log.h`** — widen `start_offset`/`lines` from `uint8_t` to `uint16_t` (`MLOG_LINES=500` overflows `uint8_t`)

## Test plan

- [x] `./tools/build.sh format` — passed clean
- [x] `./tools/build.sh --env testing` — produced `build/vitaki-fork.vpk` (3.5M) at v0.1.746

🤖 Generated with [Claude Code](https://claude.com/claude-code)