### PR TITLE
fix(psn): enforce PONG < PING interval with _Static_assert

### DIFF
--- a/lib/src/remote/holepunch.c
+++ b/lib/src/remote/holepunch.c
@@ -75,6 +75,8 @@
  * Kept shorter than WEBSOCKET_PING_INTERVAL_SEC so dead links are
  * detected before the next scheduled PING would fire. */
 #define WEBSOCKET_PONG_TIMEOUT_SEC 5
+_Static_assert(WEBSOCKET_PONG_TIMEOUT_SEC < WEBSOCKET_PING_INTERVAL_SEC,
+               "PONG timeout must be shorter than PING interval");
 // Maximum WebSocket frame size currently supported by libcurl
 #define WEBSOCKET_MAX_FRAME_SIZE 64 * 1024
 #define SESSION_CREATION_TIMEOUT_SEC 30


### PR DESCRIPTION
## Summary

- Adds a `_Static_assert` immediately after `WEBSOCKET_PONG_TIMEOUT_SEC` in `lib/src/remote/holepunch.c` to enforce at compile time that the PONG timeout is strictly shorter than the PING interval
- The comment already documented this invariant; now it's machine-checkable — a future edit that breaks the ordering will fail the build with a clear message instead of silently misbehaving

## Test plan

- [ ] Verify build succeeds with current values (5 < 10 ✓)
- [ ] Optionally: temporarily swap the constants to confirm the assert fires with `"PONG timeout must be shorter than PING interval"`

Closes (related): #164 — separate follow-up for the `select()` drift issue flagged in PR #150 review

🤖 Generated with [Claude Code](https://claude.com/claude-code)