### PR TITLE
fix(config): registered host credentials lost on every app restart (#145)

### DIFF
--- a/vita/src/config_hosts.c
+++ b/vita/src/config_hosts.c
@@ -275,7 +275,7 @@ void config_serialize_registered_hosts(FILE *fp, const VitaChiakiConfig *cfg) {
     }
 
     fprintf(fp, "\n\n[[registered_hosts]]\n");
-    serialize_b64(fp, "server_mac", rhost->server_mac, 6);
+    serialize_b64(fp, "server_mac", host->server_mac, 6);
     fprintf(fp, "server_nickname = \"%s\"\n", rhost->server_nickname);
     serialize_target(fp, "target", rhost->target);
     serialize_b64(fp, "rp_key", rhost->rp_key, 0x10);


### PR DESCRIPTION
## Summary

- `config_serialize_registered_hosts` was writing `rhost->server_mac` (the `ChiakiRegisteredHost.server_mac` field), which is **never populated** — `copy_host_registered_state()` deliberately skips `server_mac`, so it's always all-zeros after registration
- On the next launch, `config_parse_registered_hosts` rejects the entry because `bytes_nonzero(host->server_mac)` fails on the zero MAC — silently dropping the saved credentials
- This trapped users in a loop: pair → bad write → next launch → must pair again
- Fix: use `host->server_mac` (`VitaChiakiHost.server_mac`), which is always correctly set by both the registration callback and the discovery merge path

One-character change, no other files affected.

Closes #145

## Test plan

- [ ] Fresh install (no existing `config.toml`): register a PS5, close the app, reopen — console should appear as registered without re-pairing
- [ ] Existing registered user: verify previously saved credentials still load correctly after the change
- [ ] Build passes: `./tools/build.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)