### PR TITLE
fix(takion): lower Vita jitter-buffer ceiling 100ms→40ms + fix recv-thread affinity

### DIFF
--- a/DONE.md
+++ b/DONE.md
@@ -35,6 +35,15 @@ This document tracks completed work, organized by batch/date, preserving epic gr
   - Files modified: `vita/src/video_overlay.c`, `vita/include/stream_state.h`
   - Shipped together with Fix #181 in PR #183 (v0.1.783)
 
+- [x] **Bitrate Metrics Hardening & TAKION_A_RWND Experiment Closure (Fix #181 & #182 + RWND A/B, PR #193)**
+  - Verified `windowed_bitrate_mbps` calculation (time-based 3-slot ring) printing correct honest bitrate in metrics log
+  - On-device validation: measured bitrate now matches windowed_mbps= every cycle (fixes previous 0↔2 Mbps seesawing artifact from frame-count method)
+  - A/B tested TAKION_A_RWND reduction: 512KB→256KB, found no latency benefit + 4× more freezes, reverted
+  - `lib/src/takion.c` net diff = zero; value remains `0x80000` (512KB final)
+  - Bufferbloat investigation concluded; future work tracked under GH #188 (Wi-Fi/jitter-buffer domain)
+  - Files modified: (no net changes to source; experimentation validated)
+  - Merged to main in PR #193 (v0.1.784)
+
 ### Deferred Work
 - GH issue #178 (lib-layer gen/reconnect_gen tagging for PIPE/ logs) — moved to backlog after #183; spike Chiaki generation tracking first
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,6 @@
 ## PROGRESS · Roadmap & Epics
 
-Last Updated: 2026-06-25 (Bitrate metrics formula & NET_UNSTABLE debounce merged PR #183, v0.1.783)
+Last Updated: 2026-06-26 (Bitrate metrics hardening & RWND experiment closure merged PR #193, v0.1.784)
 
 A living reference for larger initiatives. Update this document when we start or finish an epic, or when priorities shift.
 
@@ -145,6 +145,7 @@ A living reference for larger initiatives. Update this document when we start or
 ### Status Log
 | Date | Update | Owner |
 |------|--------|-------|
+| 2026-06-26 | RWND experiment closure + metrics validation (PR #193, v0.1.784): A/B tested TAKION_A_RWND 512KB→256KB, found no latency benefit + 4× more freezes, reverted to 512KB (final). `vita/src/host_metrics.c` on-device validation confirms `windowed_bitrate_mbps` now prints honest bitrate every cycle (no more 0↔2 Mbps artifact). GH #188 (Wi-Fi/jitter-buffer bufferbloat) is the next domain focus. | @mauricio-gg |
 | 2026-06-25 | Bitrate metrics hardening shipped (PR #183, v0.1.783): windowed Mbps time-based formula (3-slot ring window, fixes ~100 Mbps spikes on buffer realloc), NET_UNSTABLE overlay debounce (500ms, prevents rapid redundant activation during recv bursts). GH issue #178 (lib-layer gen/reconnect_gen tagging) deferred to future spike work. | @mauricio-gg |
 | 2026-05-03 | PSN remote-play STUN DNS fix shipped (PR #158, v0.1.749) and header-hygiene followup PR submitted (v0.1.750): `vita_resolve_sin` / `vita_curl_add_resolve` forward-decl drift risk eliminated by splitting `vita_resolve.h` (curl-free) from `vita_dns.h` (curl-aware), wiring `vita/include/` as a PRIVATE chiaki-lib include dir for Vita, replacing hand-typed prototypes in `lib/src/remote/stun.h` and `holepunch.c` with real `#include` statements, and adding `<stdbool.h>` self-sufficiency + inet_ntop fallback logging. Root cause was getaddrinfo() EAI_NONAME regression in vitasdk libcurl 8.17 / GCC 15 toolchain rebuild (2026-05-02). | @mauricio-gg |
 | 2026-05-01 | Issue #122 text aliasing root cause fixed (PR #145) — vita2d font glyph atlas was sampled with POINT filtering, causing jaggy edges and baseline drift. Vendored libvita2d (`vita2d_font.c`, `texture_atlas.c`), patched to use LINEAR filter on atlas, reverted dee6831 per-glyph integer-snap workaround. Kerning restored via whole-string vita2d calls. Phase 2 (114 call-site migration) now unblocked. Build clean at v0.1.732. | @mauricio-gg |

--- a/lib/src/takion.c
+++ b/lib/src/takion.c
@@ -73,9 +73,15 @@
 // Adaptive jitter buffer constants
 #define TAKION_JITTER_MIN_THRESHOLD_US  2000   // 2ms: responsive gap timeout floor
 #ifdef __PSVITA__
-#define TAKION_JITTER_MAX_THRESHOLD_US  100000 // 100ms: Vita WiFi jitter regularly exceeds 20ms;
-                                               // allow adaptive threshold to accommodate up to
-                                               // ~40ms measured jitter (2.5×40=100ms).
+#define TAKION_JITTER_MAX_THRESHOLD_US  40000  // 40ms: ~1.2 frame intervals at 30fps; on LAN
+                                               // real network jitter is sub-ms. The old 100ms
+                                               // was derived from "2.5×~40ms measured jitter"
+                                               // but that reading is inflated by synchronous
+                                               // HW decode (~55ms) blocking this thread; it is
+                                               // not real network jitter. A/B ladder rung 1:
+                                               // 100ms -> 40ms -> 33ms -> 25ms (stop when
+                                               // missing_ref/fec_fail/corrupt climb). Tracked
+                                               // under GH #188.
                                                // Only affects out-of-order packets; in-order
                                                // packets flow through with zero added latency.
 #else
@@ -1113,10 +1119,13 @@ static void *takion_thread_func(void *user)
 	ChiakiTakion *takion = user;
 
 #ifdef __PSVITA__
-	// Pin network recv thread to USER_1 at prio 64 so it does not compete
-	// with HW decode (USER_0) or audio (USER_2) for CPU time.
+	/* Pin network recv+decode thread to USER_0 at prio 64. H.264 decode
+	 * (sceAvcdecDecode) runs synchronously on this thread, so it belongs
+	 * on USER_0 alongside the decode work. USER_2 = audio. The one-time
+	 * re-pin in vita_h264_decode_frame() (video.c) is now redundant but
+	 * harmless. */
 	sceKernelChangeThreadPriority(SCE_KERNEL_THREAD_ID_SELF, 64);
-	sceKernelChangeThreadCpuAffinityMask(SCE_KERNEL_THREAD_ID_SELF, SCE_KERNEL_CPU_MASK_USER_1);
+	sceKernelChangeThreadCpuAffinityMask(SCE_KERNEL_THREAD_ID_SELF, SCE_KERNEL_CPU_MASK_USER_0);
 #endif
 
 	uint32_t seq_num_remote_initial;

--- a/vita/src/video.c
+++ b/vita/src/video.c
@@ -554,6 +554,9 @@ int vita_h264_decode_frame(uint8_t *buf, size_t buf_size, bool frame_corrupt) {
   }
 
   chiaki_mutex_lock(&mtx);
+  /* NOTE: takion.c now pins this thread to USER_0/prio-64 at startup, so
+   * the priority + affinity set below is redundant. Kept as a safety net
+   * in case the decode work is ever moved to its own thread. */
   if (!threadSetupComplete) {
     sceKernelChangeThreadPriority(SCE_KERNEL_THREAD_ID_SELF, 64);
     sceKernelChangeThreadCpuAffinityMask(SCE_KERNEL_THREAD_ID_SELF, SCE_KERNEL_CPU_MASK_USER_0);


### PR DESCRIPTION
## Summary

Two small targeted changes to improve LAN remote-play latency, both in the Takion receive-thread subsystem. This is **A/B rung 1** for GH #188.

### 1. Lower Vita jitter-buffer ceiling 100 ms → 40 ms (`lib/src/takion.c:76`)

The adaptive gap-wait timeout is clamped to `[TAKION_JITTER_MIN_THRESHOLD_US, TAKION_JITTER_MAX_THRESHOLD_US]`. On Vita the ceiling has been 100 ms, justified by "2.5 × ~40 ms measured jitter = 100 ms".

Investigation revealed: **that ~40 ms "jitter" is not real network jitter**. H.264 decode (`sceAvcdecDecode`) runs *synchronously* on the Takion receive thread (call chain: `takion_thread_func → host_video_cb → vita_h264_decode_frame → sceAvcdecDecode`). While a frame decodes, the recv loop cannot drain the socket, which inflates the inter-arrival EWMA to `decode_avg_ms` (~55 ms). The adaptive threshold then computes `2.5 × 55ms = 137ms → clamped to 100ms`. On LAN, real network jitter is sub-millisecond.

**Change:** ceiling lowered to **40 ms** (~1.2 frame intervals at 30 fps). A truly lost packet now gets skipped in at most 40 ms instead of 100 ms. In-order packets are unaffected (zero-added-latency path unchanged).

**A/B ladder** (watch `missing_ref / fec_fail / corrupt_bursts` via existing `host_metrics.c` AV diag line):
`100 ms → 40 ms → 33 ms → 25 ms` — stop if corruption climbs.

### 2. Fix recv-thread CPU-affinity conflict (`lib/src/takion.c:1119` + `vita/src/video.c:557`)

Pre-existing bug: the Takion recv thread was pinning itself to `CPU_MASK_USER_1` at startup (`takion.c:1119`), then `vita_h264_decode_frame()` (running on that *same* thread) re-pinned it to `CPU_MASK_USER_0` on first decode (`video.c:559`). The USER_1 assignment was dead/contradictory — the thread silently migrated cores on frame 1.

**Fix:** set USER_0 at startup in `takion.c` so placement is explicit and stable from the first packet. The `video.c` re-pin block is retained as a safety net (with a NOTE comment) in case decode is later split to its own thread (the root-cause fix tracked in GH #188).

CPU map after this change:
| Thread | Core | Priority |
|---|---|---|
| recv + decode (Takion) | USER_0 | 64 |
| audio | USER_2 | 64 |
| input/motion | any | 96 |

## A/B comparison baseline

Same metrics table as PR #193 RWND A/B. Run both builds on hardware via `./tools/build.sh --env testing`:

```
Metrics to compare (host_metrics.c, 1s cadence + AV diag):
  - jitter_us, freeze count, PIPE/missing_ref
  - fec_fail, corrupt_bursts
  - gaps_skipped (expected to rise — skip sooner = fewer frames held back)
```

Win condition: lower/flat `freeze` and tail latency, no meaningful rise in `missing_ref / fec_fail / corrupt`. If corruption climbs, next rung (33 ms) is the revert point.

## Out of scope / follow-up

The root-cause of the inflated jitter EWMA is **synchronous decode on the recv thread**. Decoupling decode onto its own thread (AU handoff queue + dedicated USER_0 decode thread) would lower the EWMA to true network jitter, auto-tightening the adaptive threshold further. This PR is the data-gathering step; if jitter stays elevated after this change, that confirms decode-blocking and green-lights the bigger architecture change under GH #188.

## Test plan

- [ ] `./tools/build.sh format` — ✅ passed before commit
- [ ] Code review — ✅ approved by `senior-code-guardian`
- [ ] Build baseline VPK from `main` via `./tools/build.sh --env testing`
- [ ] Build experiment VPK from this branch via `./tools/build.sh --env testing`
- [ ] Deploy both to Vita, run same LAN session, compare `host_metrics.c` output table
- [ ] Confirm `freeze` ≤ baseline and `missing_ref / fec_fail / corrupt` are flat/lower

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKA1GLx3nisKqZaJDds6sb
