### PR TITLE
test(power): A/B scePowerSetUsingWireless(1) — probe Wi-Fi power-save jitter

### DIFF
--- a/vita/src/main.c
+++ b/vita/src/main.c
@@ -54,8 +54,6 @@ static int vita_init() {
   scePowerSetGpuClockFrequency(222);
   scePowerSetBusClockFrequency(222);
   scePowerSetGpuXbarClockFrequency(166);
-  int wireless_ret = scePowerSetUsingWireless(1);
-  LOGD("scePowerSetUsingWireless(1) = 0x%x", wireless_ret);
   // Seed OpenSSL
   char random_seed[0x40] = {0};
   sceKernelGetRandomNumber(random_seed, sizeof(random_seed));
@@ -140,12 +138,16 @@ unsigned int _newlib_heap_size_user = 64 * 1024 * 1024;
 int main(int argc, char *argv[]) {
   vita_init();
 
-  // Note: Power management is configured in vita_init() (scePowerSet* calls)
+  // Note: Clock frequencies are configured in vita_init() (scePowerSet* calls).
+  // scePowerSetUsingWireless() is set after vita_chiaki_init_context() so the
+  // result is captured in the log (log sink is not live during vita_init()).
   // Note: Input thread is created per-stream in host.c when streaming starts
 
   sceIoMkdir("ux0:/data/vita-chiaki", 0777);
 
   vita_chiaki_init_context();
+  int wireless_ret = scePowerSetUsingWireless(1);
+  LOGD("scePowerSetUsingWireless(1) = 0x%x", wireless_ret);
   if (context.config.auto_discovery) {
     LOGD("Starting discovery");
     ChiakiErrorCode err = start_discovery(NULL, NULL);

--- a/vita/src/main.c
+++ b/vita/src/main.c
@@ -54,6 +54,8 @@ static int vita_init() {
   scePowerSetGpuClockFrequency(222);
   scePowerSetBusClockFrequency(222);
   scePowerSetGpuXbarClockFrequency(166);
+  int wireless_ret = scePowerSetUsingWireless(1);
+  LOGD("scePowerSetUsingWireless(1) = 0x%x", wireless_ret);
   // Seed OpenSSL
   char random_seed[0x40] = {0};
   sceKernelGetRandomNumber(random_seed, sizeof(random_seed));

--- a/vita/src/main.c
+++ b/vita/src/main.c
@@ -146,6 +146,9 @@ int main(int argc, char *argv[]) {
   sceIoMkdir("ux0:/data/vita-chiaki", 0777);
 
   vita_chiaki_init_context();
+  // A/B tested PR #198 (2026-06-27): confirmed applied (0x0) but no measurable
+  // effect on jitter or RTT. Kept as foundation for a future battery-saving
+  // toggle in settings (separate PR).
   int wireless_ret = scePowerSetUsingWireless(1);
   LOGD("scePowerSetUsingWireless(1) = 0x%x", wireless_ret);
   if (context.config.auto_discovery) {


### PR DESCRIPTION
## Summary

- Adds a single call `scePowerSetUsingWireless(1)` in `vita_init()` (`main.c:57`) alongside the existing clock-overclock calls.
- `<psp2/power.h>` is already included — no new dependency.
- Return value logged via `LOGD` at startup so hardware test logs confirm the hint was applied (or show a failure code).
- Never aborts on non-zero return — strictly best-effort.

## Why

Log analysis of three recent testing sessions identified the dominant jitter source as a **repeating sawtooth RTT: 0 → ~190 ms**, constant 5 ms base, loss decoupled from RTT, stable RSSI (58–64%). This is the textbook signature of 802.11 power-save buffering (radio sleeps between beacons → AP queues video → drains in a burst).

The VitaSDK exposes **no direct power-save toggle** (confirmed by grepping `psp2/` headers in the Docker image — no WLAN/PS-Poll/DTIM/U-APSD API exists). `scePowerSetUsingWireless` (`psp2/power.h:233`) is the only userland lever: a power-manager hint that wireless is actively in use.

The app currently calls this for **nothing** — only the four clock overclocks are in `vita_init()`.

**Two changes were ruled out and dropped:**
- Lowering the requested LAN bitrate (6000 kbps): the PS5 ignores our request ceiling and self-throttles to a 1.5 Mbps floor on congestion — a lower static request can't raise delivered throughput. Red herring.
- Decode-on-recv-thread decouple: real and worth fixing (see GH #188), but the next step, not this one.

## Test plan

- [ ] Build: `./tools/build.sh --env testing`
- [ ] Deploy to Vita, stream 540p, reproduce the Wi-Fi stress scenario (the PS-button interrupt / hold ≥60s)
- [ ] Capture a fresh `*_vitarps5-testing.log`
- [ ] **Success signal**: RTT sawtooth flattens — baseline median RTT ~101 ms / max ~191 ms / jitter_us ~58 ms shrinks meaningfully
- [ ] **Confirm** log shows `scePowerSetUsingWireless(1) = 0x0` (0 = success)
- [ ] **If no effect**: revert this single line, record negative result, proceed to decode decouple (#188)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKA1GLx3nisKqZaJDds6sb